### PR TITLE
fix: remove default pagination to allow streaming responses by default

### DIFF
--- a/search/request.go
+++ b/search/request.go
@@ -100,11 +100,6 @@ func (b *requestBuilder) Build() *Request {
 		i++
 	}
 
-	// default options
-	if b.options == nil {
-		b.options = &DefaultSearchOptions
-	}
-
 	return &Request{
 		Q:            b.q,
 		SearchFields: searchFields,

--- a/search/request_test.go
+++ b/search/request_test.go
@@ -36,7 +36,7 @@ func TestRequestBuilder_Build(t *testing.T) {
 		assert.Empty(t, req.Filter)
 		assert.Empty(t, req.Facet)
 		assert.Empty(t, req.ReadFields)
-		assert.Exactly(t, *req.Options, DefaultSearchOptions)
+		assert.Nil(t, req.Options)
 	})
 
 	t.Run("with search fields", func(t *testing.T) {

--- a/tigris/collection.go
+++ b/tigris/collection.go
@@ -204,9 +204,12 @@ func getSearchRequest(req *search.Request) (*driver.SearchRequest, error) {
 	r := driver.SearchRequest{
 		Q:            req.Q,
 		SearchFields: req.SearchFields,
-		Page:         req.Options.Page,
-		PageSize:     req.Options.PageSize,
 	}
+	if req.Options != nil {
+		r.Page = req.Options.Page
+		r.PageSize = req.Options.PageSize
+	}
+
 	f, err := req.Filter.Build()
 	if err != nil {
 		return nil, err

--- a/tigris/collection_test.go
+++ b/tigris/collection_test.go
@@ -128,8 +128,8 @@ func TestGetSearchRequest(t *testing.T) {
 		out, err := getSearchRequest(in)
 		assert.Nil(t, err)
 		assert.NotNil(t, out)
-		assert.Equal(t, search.DefaultSearchOptions.Page, out.Page)
-		assert.Equal(t, search.DefaultSearchOptions.PageSize, out.PageSize)
+		assert.Equal(t, int32(0), out.Page)
+		assert.Equal(t, int32(0), out.PageSize)
 		assert.Nil(t, out.Filter)
 		assert.Nil(t, out.Facet)
 		assert.Equal(t, driver.SearchProjection(`{}`), out.ReadFields)
@@ -337,8 +337,8 @@ func TestCollection_Search(t *testing.T) {
 			Filter:       nil,
 			Facet:        nil,
 			ReadFields:   driver.SearchProjection(`{}`),
-			Page:         search.DefaultSearchOptions.Page,
-			PageSize:     search.DefaultSearchOptions.PageSize,
+			Page:         int32(0),
+			PageSize:     int32(0),
 		}).Return(rit, nil)
 		searchIter, err := c.Search(ctx, sr)
 		require.NoError(t, err)


### PR DESCRIPTION
- Removing default pagination options from search  request