### PR TITLE
refactor: Match all and facet querying improvement to search

### DIFF
--- a/search/request.go
+++ b/search/request.go
@@ -41,6 +41,10 @@ type Request struct {
 	Options *Options
 }
 
+func MatchAll() RequestBuilder {
+	return NewRequestBuilder().WithQuery("")
+}
+
 func NewRequestBuilder() RequestBuilder {
 	return &requestBuilder{
 		searchFields: make(map[string]bool)}
@@ -50,6 +54,7 @@ type RequestBuilder interface {
 	WithQuery(q string) RequestBuilder
 	WithSearchFields(fields ...string) RequestBuilder
 	WithFilter(filter.Filter) RequestBuilder
+	WithFacetFields(fields ...string) RequestBuilder
 	WithFacet(*FacetQuery) RequestBuilder
 	WithReadFields(readFields *ReadFields) RequestBuilder
 	WithOptions(*Options) RequestBuilder
@@ -79,6 +84,12 @@ func (b *requestBuilder) WithSearchFields(fields ...string) RequestBuilder {
 
 func (b *requestBuilder) WithFilter(f filter.Filter) RequestBuilder {
 	b.filter = f
+	return b
+}
+
+func (b *requestBuilder) WithFacetFields(fields ...string) RequestBuilder {
+	facetQuery := NewFacetQueryBuilder().WithFields(fields...).Build()
+	b.facet = facetQuery
 	return b
 }
 

--- a/search/request_test.go
+++ b/search/request_test.go
@@ -26,6 +26,11 @@ import (
 	"github.com/tigrisdata/tigris-client-go/driver"
 )
 
+func TestMatchAllQuery(t *testing.T) {
+	req := MatchAll().Build()
+	assert.Equal(t, "", req.Q)
+}
+
 func TestRequestBuilder_Build(t *testing.T) {
 	inputQ := "search text"
 
@@ -43,6 +48,14 @@ func TestRequestBuilder_Build(t *testing.T) {
 		req := NewRequestBuilder().WithQuery(inputQ).WithSearchFields("field_1", "field_2").Build()
 		assert.Len(t, req.SearchFields, 2)
 		assert.Subset(t, []string{"field_1", "field_2"}, req.SearchFields)
+	})
+
+	t.Run("with facet fields", func(t *testing.T) {
+		req := NewRequestBuilder().WithFacetFields("field_1", "field_2").Build()
+		assert.Len(t, req.Facet.FacetFields, 2)
+		for f, _ := range req.Facet.FacetFields {
+			assert.Contains(t, []string{"field_1", "field_2"}, f)
+		}
 	})
 }
 


### PR DESCRIPTION
- Introduced a simpler `WithFacetFields(fields ...string)` construct
- Introduced a MatchAll query for facet only or filter only searches