### PR TITLE
Improve configuration handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ mock: mock/api/grpc.go mock/driver.go
 lint:
 	yq --exit-status 'tag == "!!map" or tag== "!!seq"' .github/workflows/*.yaml
 	shellcheck scripts/*
-	golangci-lint run
+	golangci-lint run --fix
 
 go.sum: go.mod generate mock
 	go mod download

--- a/api/server/v1/error.go
+++ b/api/server/v1/error.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/golang/protobuf/proto" //nolint:golint,staticcheck
+	"github.com/golang/protobuf/proto" //nolint:staticcheck
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	spb "google.golang.org/genproto/googleapis/rpc/status"

--- a/config/config.go
+++ b/config/config.go
@@ -24,10 +24,11 @@ type Driver struct {
 	ClientSecret string      `json:"client_secret,omitempty"`
 	Token        string      `json:"token,omitempty"`
 	URL          string      `json:"url,omitempty"`
+	Protocol     string      `json:"protocol,omitempty"`
 }
 
-// Database contains database and connection config.
-type Database struct {
+// Client contains database and connection config.
+type Client struct {
 	Driver
 	// MustExist if set skips implicit database creation
 	MustExist bool

--- a/driver/config_test.go
+++ b/driver/config_test.go
@@ -1,0 +1,199 @@
+// Copyright 2022 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package driver
+
+import (
+	"crypto/tls"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tigrisdata/tigris-client-go/config"
+)
+
+func TestDriverConfig(t *testing.T) {
+	TLS := &tls.Config{MinVersion: tls.VersionTLS12}
+
+	cases := []struct {
+		name string
+		url  string
+		cfg  *config.Driver
+		err  error
+	}{
+		{name: "host", url: "host1", cfg: &config.Driver{URL: "host1", Protocol: GRPC}},
+		{name: "host_with_port", url: "host1:333", cfg: &config.Driver{URL: "host1:333", Protocol: GRPC}},
+		{name: "localhost", url: "localhost", cfg: &config.Driver{URL: "localhost", Protocol: GRPC}},
+		{name: "localhost_with_port", url: "localhost:555", cfg: &config.Driver{URL: "localhost:555", Protocol: GRPC}},
+		{name: "ip", url: "127.0.0.1", cfg: &config.Driver{URL: "127.0.0.1", Protocol: GRPC}},
+		{name: "ip_with_port", url: "127.0.0.1:777", cfg: &config.Driver{URL: "127.0.0.1:777", Protocol: GRPC}},
+		{name: "https_ipv6", url: "https://[::1]", cfg: &config.Driver{URL: "[::1]", Protocol: HTTP, TLS: TLS}},
+		{name: "https_ipv6_with_port", url: "https://[::1]:777", cfg: &config.Driver{URL: "[::1]:777", Protocol: HTTP, TLS: TLS}},
+		{name: "ipv6", url: "::1", cfg: &config.Driver{URL: "::1", Protocol: GRPC}},
+		{name: "ipv6_with_port", url: "[::1]:777", cfg: &config.Driver{URL: "[::1]:777", Protocol: GRPC}},
+		{name: "http_host", url: "http://host1", cfg: &config.Driver{URL: "host1", Protocol: HTTP}},
+		{name: "http_host_with_port", url: "http://host1:333", cfg: &config.Driver{URL: "host1:333", Protocol: HTTP}},
+		{name: "http_localhost", url: "http://localhost", cfg: &config.Driver{URL: "localhost", Protocol: HTTP}},
+		{name: "http_localhost_with_port", url: "http://localhost:555", cfg: &config.Driver{URL: "localhost:555", Protocol: HTTP}},
+		{name: "http_ip", url: "http://127.0.0.1", cfg: &config.Driver{URL: "127.0.0.1", Protocol: HTTP}},
+		{name: "http_ip_with_port", url: "http://127.0.0.1:777", cfg: &config.Driver{URL: "127.0.0.1:777", Protocol: HTTP}},
+		{name: "https_host", url: "https://host1", cfg: &config.Driver{URL: "host1", Protocol: HTTP, TLS: TLS}},
+		{name: "https_host_with_port", url: "https://host1:333", cfg: &config.Driver{URL: "host1:333", Protocol: HTTP, TLS: TLS}},
+		{name: "https_localhost", url: "https://localhost", cfg: &config.Driver{URL: "localhost", Protocol: HTTP, TLS: TLS}},
+		{name: "https_localhost_with_port", url: "https://localhost:555", cfg: &config.Driver{URL: "localhost:555", Protocol: HTTP, TLS: TLS}},
+		{name: "https_ip", url: "https://127.0.0.1", cfg: &config.Driver{URL: "127.0.0.1", Protocol: HTTP, TLS: TLS}},
+		{name: "https_ip_with_port", url: "https://127.0.0.1:777", cfg: &config.Driver{URL: "127.0.0.1:777", Protocol: HTTP, TLS: TLS}},
+		{name: "grpc_host", url: "grpc://host1", cfg: &config.Driver{URL: "host1", Protocol: GRPC}},
+		{name: "grpc_host_with_port", url: "grpc://host1:333", cfg: &config.Driver{URL: "host1:333", Protocol: GRPC}},
+		{name: "grpc_localhost", url: "grpc://localhost", cfg: &config.Driver{URL: "localhost", Protocol: GRPC}},
+		{name: "grpc_localhost_with_port", url: "grpc://localhost:555", cfg: &config.Driver{URL: "localhost:555", Protocol: GRPC}},
+		{name: "grpc_ip", url: "grpc://127.0.0.1", cfg: &config.Driver{URL: "127.0.0.1", Protocol: GRPC}},
+		{name: "grpc_ip_with_port", url: "grpc://127.0.0.1:777", cfg: &config.Driver{URL: "127.0.0.1:777", Protocol: GRPC}},
+		{name: "https_host_query", url: "https://host1?client_id=usr1&client_secret=pwd1", cfg: &config.Driver{URL: "host1", Protocol: HTTP, TLS: TLS, ClientID: "usr1", ClientSecret: "pwd1"}},
+		{name: "https_host_with_port_query", url: "https://host1:333?client_id=usr1&client_secret=pwd1", cfg: &config.Driver{URL: "host1:333", Protocol: HTTP, TLS: TLS, ClientID: "usr1", ClientSecret: "pwd1"}},
+		{name: "https_localhost_query", url: "https://localhost?client_id=usr1&client_secret=pwd1", cfg: &config.Driver{URL: "localhost", Protocol: HTTP, TLS: TLS, ClientID: "usr1", ClientSecret: "pwd1"}},
+		{name: "https_localhost_with_port_query", url: "https://localhost:555?client_id=usr1&client_secret=pwd1", cfg: &config.Driver{URL: "localhost:555", Protocol: HTTP, TLS: TLS, ClientID: "usr1", ClientSecret: "pwd1"}},
+		{name: "https_ip_query", url: "https://127.0.0.1?client_id=usr1&client_secret=pwd1", cfg: &config.Driver{URL: "127.0.0.1", Protocol: HTTP, TLS: TLS, ClientID: "usr1", ClientSecret: "pwd1"}},
+		{name: "https_ip_with_port_query", url: "https://127.0.0.1:777?client_id=usr1&client_secret=pwd1", cfg: &config.Driver{URL: "127.0.0.1:777", Protocol: HTTP, TLS: TLS, ClientID: "usr1", ClientSecret: "pwd1"}},
+		{name: "https_host_userinfo", url: "https://usr1:pwd1@host1", cfg: &config.Driver{URL: "host1", Protocol: HTTP, TLS: TLS, ClientID: "usr1", ClientSecret: "pwd1"}},
+		{name: "https_host_with_port_userinfo", url: "https://usr1:pwd1@host1:333", cfg: &config.Driver{URL: "host1:333", Protocol: HTTP, TLS: TLS, ClientID: "usr1", ClientSecret: "pwd1"}},
+		{name: "https_localhost_userinfo", url: "https://usr1:pwd1@localhost", cfg: &config.Driver{URL: "localhost", Protocol: HTTP, TLS: TLS, ClientID: "usr1", ClientSecret: "pwd1"}},
+		{name: "https_localhost_with_port_userinfo", url: "https://usr1:pwd1@localhost:555", cfg: &config.Driver{URL: "localhost:555", Protocol: HTTP, TLS: TLS, ClientID: "usr1", ClientSecret: "pwd1"}},
+		{name: "https_ip_userinfo", url: "https://usr1:pwd1@127.0.0.1", cfg: &config.Driver{URL: "127.0.0.1", Protocol: HTTP, TLS: TLS, ClientID: "usr1", ClientSecret: "pwd1"}},
+		{name: "https_ip_with_port_userinfo", url: "https://usr1:pwd1@127.0.0.1:777", cfg: &config.Driver{URL: "127.0.0.1:777", Protocol: HTTP, TLS: TLS, ClientID: "usr1", ClientSecret: "pwd1"}},
+		{name: "ip_with_port_userinfo", url: "usr1:pwd1@127.0.0.1:777", cfg: &config.Driver{URL: "127.0.0.1:777", Protocol: GRPC, TLS: TLS, ClientID: "usr1", ClientSecret: "pwd1"}},
+		{name: "dns_host", url: "dns://host1", cfg: &config.Driver{URL: "host1", Protocol: GRPC}},
+		{name: "dns_host_with_port", url: "dns://host1:333", cfg: &config.Driver{URL: "host1:333", Protocol: GRPC}},
+		{name: "dns_localhost", url: "dns://localhost", cfg: &config.Driver{URL: "localhost", Protocol: GRPC}},
+		{name: "dns_localhost_with_port", url: "dns://localhost:555", cfg: &config.Driver{URL: "localhost:555", Protocol: GRPC}},
+		{name: "dns_ip", url: "dns://127.0.0.1", cfg: &config.Driver{URL: "127.0.0.1", Protocol: GRPC}},
+		{name: "dns_ip_with_port", url: "dns://127.0.0.1:777", cfg: &config.Driver{URL: "127.0.0.1:777", Protocol: GRPC}},
+
+		{name: "https_host_token", url: "https://host1?token=tkn1", cfg: &config.Driver{URL: "host1", Protocol: HTTP, TLS: TLS, Token: "tkn1"}},
+		{name: "https_host_with_port_token", url: "https://host1:333?token=tkn1", cfg: &config.Driver{URL: "host1:333", Protocol: HTTP, TLS: TLS, Token: "tkn1"}},
+		{name: "https_localhost_token", url: "https://localhost?token=tkn1", cfg: &config.Driver{URL: "localhost", Protocol: HTTP, TLS: TLS, Token: "tkn1"}},
+		{name: "https_localhost_with_port_token", url: "https://localhost:555?token=tkn1", cfg: &config.Driver{URL: "localhost:555", Protocol: HTTP, TLS: TLS, Token: "tkn1"}},
+		{name: "https_ip_token", url: "https://127.0.0.1?token=tkn1", cfg: &config.Driver{URL: "127.0.0.1", Protocol: HTTP, TLS: TLS, Token: "tkn1"}},
+		{name: "https_ip_with_port_token", url: "https://127.0.0.1:777?token=tkn1", cfg: &config.Driver{URL: "127.0.0.1:777", Protocol: HTTP, TLS: TLS, Token: "tkn1"}},
+	}
+
+	for _, v := range cases {
+		t.Run(v.name, func(t *testing.T) {
+			cfg := config.Driver{URL: v.url}
+			rcfg, err := initConfig(&cfg)
+			assert.Equal(t, v.err, err)
+			assert.Equal(t, v.cfg, rcfg)
+		})
+	}
+}
+
+func TestDriverConfigPrecedence(t *testing.T) {
+	TLS := &tls.Config{MinVersion: tls.VersionTLS12}
+
+	cfg := config.Driver{}
+
+	res, err := initConfig(&cfg)
+	assert.NoError(t, err)
+
+	// default
+	assert.Equal(t, config.Driver{URL: "api.preview.tigrisdata.cloud", Protocol: GRPC}, *res)
+
+	// env have precedence over default
+	t.Setenv(EnvToken, "token1")
+	t.Setenv(EnvClientID, "client1")
+	t.Setenv(EnvClientSecret, "client_secret1")
+	t.Setenv(EnvURL, "host1:234")
+	t.Setenv(EnvProtocol, "HTTP")
+
+	res, err = initConfig(&cfg)
+	assert.NoError(t, err)
+	assert.Equal(t, config.Driver{
+		URL:          "host1:234",
+		ClientID:     "client1",
+		ClientSecret: "client_secret1",
+		Token:        "token1",
+		Protocol:     HTTP,
+		TLS:          TLS,
+	}, *res)
+
+	// config have precedence over config
+	cfg.URL = "url.config"
+	cfg.ClientID = "client_id2"
+	cfg.ClientSecret = "client_secret2"
+	cfg.Protocol = "GRPC"
+	cfg.Token = "token2"
+	res, err = initConfig(&cfg)
+	assert.NoError(t, err)
+
+	assert.Equal(t, config.Driver{
+		URL:          "url.config",
+		ClientID:     "client_id2",
+		ClientSecret: "client_secret2",
+		Token:        "token2",
+		Protocol:     GRPC,
+		TLS:          TLS,
+	}, *res)
+
+	// URL params have precedence over config
+	cfg.URL = "https://ii.ii?client_id=id3&client_secret=secret3&token=token3"
+	res, err = initConfig(&cfg)
+	assert.NoError(t, err)
+
+	assert.Equal(t, config.Driver{
+		URL:          "ii.ii",
+		ClientID:     "id3",
+		ClientSecret: "secret3",
+		Token:        "token3",
+		Protocol:     HTTP,
+		TLS:          TLS,
+	}, *res)
+}
+
+func TestDriverConfigNegative(t *testing.T) {
+	cfg := config.Driver{}
+	cfg.URL = "::+invlaid//"
+	_, err := initConfig(&cfg)
+	assert.Error(t, err)
+
+	cfg.URL = ""
+	t.Setenv(EnvProtocol, "INVALID")
+	_, err = initConfig(&cfg)
+	assert.Error(t, err)
+}
+
+func TestDriverConfigProto(t *testing.T) {
+	cases := []struct {
+		proto string
+		exp   string
+		err   error
+	}{
+		{proto: "GRPC", exp: GRPC},
+		{proto: "HTTP", exp: HTTP},
+		{proto: "http", exp: HTTP},
+		{proto: "grpc", exp: GRPC},
+		{proto: "HtTp", exp: HTTP},
+		{proto: "GrPc", exp: GRPC},
+		{proto: "INVALID", exp: "INVALID", err: fmt.Errorf("unsupported protocol")},
+		{proto: "HTTPS", exp: HTTP},
+	}
+
+	for _, v := range cases {
+		t.Run(v.proto, func(t *testing.T) {
+			cfg := config.Driver{Protocol: v.proto}
+			_, err := initProto("", &cfg)
+			assert.Equal(t, v.err, err)
+			assert.Equal(t, v.exp, cfg.Protocol)
+		})
+	}
+}

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -1115,8 +1115,10 @@ func TestNewDriver(t *testing.T) {
 	_, err = NewDriver(context.Background(), nil)
 	require.Error(t, err)
 
+	DefaultProtocol = GRPC
 	cfg1 := &config.Driver{URL: test.GRPCURL(4), ClientSecret: "aaaa"}
-	cfg1 = initConfig(cfg1)
+	cfg1, err = initConfig(cfg1)
+	require.NoError(t, err)
 	require.NotNil(t, cfg1.TLS)
 }
 

--- a/driver/grpc.go
+++ b/driver/grpc.go
@@ -57,7 +57,7 @@ func GRPCError(err error) error {
 }
 
 // newGRPCClient return Driver interface implementation using GRPC transport protocol.
-func newGRPCClient(_ context.Context, url string, config *config.Driver) (*grpcDriver, error) {
+func newGRPCClient(ctx context.Context, url string, config *config.Driver) (*grpcDriver, error) {
 	if !strings.Contains(url, ":") {
 		url = fmt.Sprintf("%s:%d", url, DefaultGRPCPort)
 	}
@@ -81,7 +81,7 @@ func newGRPCClient(_ context.Context, url string, config *config.Driver) (*grpcD
 		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	}
 
-	conn, err := grpc.Dial(url, opts...)
+	conn, err := grpc.DialContext(ctx, url, opts...)
 	if err != nil {
 		return nil, GRPCError(err)
 	}

--- a/driver/management.go
+++ b/driver/management.go
@@ -17,8 +17,6 @@ package driver
 import (
 	"context"
 	"fmt"
-	"os"
-	"strings"
 
 	"github.com/tigrisdata/tigris-client-go/config"
 )
@@ -40,19 +38,17 @@ type Management interface {
 
 // NewManagement instantiates authentication API client.
 func NewManagement(ctx context.Context, cfg *config.Driver) (Management, error) {
-	cfg = initConfig(cfg)
-
-	protocol := DefaultProtocol
-	if os.Getenv(EnvProtocol) != "" {
-		protocol = strings.ToUpper(os.Getenv(EnvProtocol))
-	}
-
 	var (
 		mgmt Management
 		err  error
 	)
 
-	switch protocol {
+	cfg, err = initConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	switch cfg.Protocol {
 	case GRPC:
 		mgmt, err = newGRPCClient(ctx, cfg.URL, cfg)
 	case HTTP:
@@ -61,9 +57,5 @@ func NewManagement(ctx context.Context, cfg *config.Driver) (Management, error) 
 		err = fmt.Errorf("unsupported protocol")
 	}
 
-	if err != nil {
-		return nil, err
-	}
-
-	return mgmt, nil
+	return mgmt, err
 }

--- a/driver/management_test.go
+++ b/driver/management_test.go
@@ -302,9 +302,10 @@ func TestGRPCDriverCredentials(t *testing.T) {
 		t.Setenv(EnvClientID, "client_id_test")
 		t.Setenv(EnvClientSecret, "client_secret_test")
 
-		client, _, mockServers, cancel := SetupMgmtGRPCTests(t, &config.Driver{
-			URL: test.GRPCURL(0),
-		})
+		cfg, err := initConfig(&config.Driver{URL: test.GRPCURL(0)})
+		require.NoError(t, err)
+
+		client, _, mockServers, cancel := SetupMgmtGRPCTests(t, cfg)
 		defer cancel()
 
 		testDriverToken(t, client, mockServers.API, mockServers.Auth, "token_config_123", true)
@@ -332,9 +333,10 @@ func TestHTTPDriverCredentials(t *testing.T) {
 		t.Setenv(EnvClientID, "client_id_test")
 		t.Setenv(EnvClientSecret, "client_secret_test")
 
-		client, _, mockServers, cancel := SetupMgmtHTTPTests(t, &config.Driver{
-			URL: test.HTTPURL(2),
-		})
+		cfg, err := initConfig(&config.Driver{URL: test.HTTPURL(2)})
+		require.NoError(t, err)
+
+		client, _, mockServers, cancel := SetupMgmtHTTPTests(t, cfg)
 		defer cancel()
 
 		testDriverToken(t, client, mockServers.API, mockServers.Auth, "token_config_123", true)
@@ -361,9 +363,10 @@ func TestGRPCDriverToken(t *testing.T) {
 
 		t.Setenv(EnvToken, "token_grpc_env_1")
 
-		client, _, mockServers, cancel := SetupMgmtGRPCTests(t, &config.Driver{
-			URL: test.GRPCURL(0),
-		})
+		cfg, err := initConfig(&config.Driver{URL: test.GRPCURL(0)})
+		require.NoError(t, err)
+
+		client, _, mockServers, cancel := SetupMgmtGRPCTests(t, cfg)
 		defer cancel()
 
 		testDriverToken(t, client, mockServers.API, mockServers.Auth, "token_grpc_env_1", false)
@@ -387,9 +390,10 @@ func TestHTTPDriverToken(t *testing.T) {
 
 		t.Setenv(EnvToken, "token_http_env_1")
 
-		client, _, mockServers, cancel := SetupMgmtHTTPTests(t, &config.Driver{
-			URL: test.HTTPURL(2),
-		})
+		cfg, err := initConfig(&config.Driver{URL: test.HTTPURL(2)})
+		require.NoError(t, err)
+
+		client, _, mockServers, cancel := SetupMgmtHTTPTests(t, cfg)
 		defer cancel()
 
 		testDriverToken(t, client, mockServers.API, mockServers.Auth, "token_http_env_1", false)

--- a/driver/observability.go
+++ b/driver/observability.go
@@ -17,8 +17,6 @@ package driver
 import (
 	"context"
 	"fmt"
-	"os"
-	"strings"
 
 	"github.com/tigrisdata/tigris-client-go/config"
 )
@@ -33,19 +31,17 @@ type Observability interface {
 
 // NewObservability instantiates observability API client.
 func NewObservability(ctx context.Context, cfg *config.Driver) (Observability, error) {
-	cfg = initConfig(cfg)
-
-	protocol := DefaultProtocol
-	if os.Getenv(EnvProtocol) != "" {
-		protocol = strings.ToUpper(os.Getenv(EnvProtocol))
-	}
-
 	var (
 		o11y Observability
 		err  error
 	)
 
-	switch protocol {
+	cfg, err = initConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	switch cfg.Protocol {
 	case GRPC:
 		o11y, err = newGRPCClient(ctx, cfg.URL, cfg)
 	case HTTP:

--- a/driver/types.go
+++ b/driver/types.go
@@ -30,6 +30,7 @@ const (
 	EnvClientSecret = "TIGRIS_CLIENT_SECRET" //nolint:golint,gosec
 	EnvToken        = "TIGRIS_TOKEN"         //nolint:golint,gosec
 	EnvProtocol     = "TIGRIS_PROTOCOL"
+	EnvURL          = "TIGRIS_URL"
 
 	Version   = "v1.0.0"
 	UserAgent = "tigris-client-go/" + Version
@@ -39,6 +40,7 @@ const (
 
 var (
 	DefaultProtocol = GRPC
+	DefaultURL      = "api.preview.tigrisdata.cloud"
 
 	// TokenURLOverride Only used in tests to point auth to proper HTTP port in GRPC tests.
 	TokenURLOverride string

--- a/tigris/client.go
+++ b/tigris/client.go
@@ -16,6 +16,7 @@ package tigris
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/tigrisdata/tigris-client-go/config"
 	"github.com/tigrisdata/tigris-client-go/driver"
@@ -25,17 +26,26 @@ import (
 // Client responsible for connecting to the server and opening a database.
 type Client struct {
 	driver driver.Driver
-	config *config.Database
+	config *config.Client
 }
 
 // NewClient creates a connection to the Tigris server.
-func NewClient(ctx context.Context, cfg *config.Database) (*Client, error) {
-	d, err := driver.NewDriver(ctx, &cfg.Driver)
+func NewClient(ctx context.Context, cfg ...*config.Client) (*Client, error) {
+	var pCfg config.Client
+
+	if len(cfg) > 0 {
+		if len(cfg) != 1 {
+			return nil, fmt.Errorf("only one config structure allowed")
+		}
+		pCfg = *cfg[0]
+	}
+
+	d, err := driver.NewDriver(ctx, &pCfg.Driver)
 	if err != nil {
 		return nil, err
 	}
 
-	return &Client{driver: d, config: cfg}, nil
+	return &Client{driver: d, config: &pCfg}, nil
 }
 
 // Close terminates client connections and release resources.

--- a/tigris/client_test.go
+++ b/tigris/client_test.go
@@ -35,7 +35,7 @@ func TestClient(t *testing.T) {
 	ctx, cancel1 := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel1()
 
-	cfg := &config.Database{Driver: config.Driver{URL: test.GRPCURL(8)}}
+	cfg := &config.Client{Driver: config.Driver{URL: test.GRPCURL(8)}}
 	cfg.TLS = test.SetupTLS(t)
 
 	type Coll1 struct {
@@ -94,7 +94,11 @@ func TestClient(t *testing.T) {
 	err = c.Close()
 	require.NoError(t, err)
 
-	cfg.URL = "http://invalid"
+	cfg.URL = "http:++//invalid"
 	_, err = NewClient(ctx, cfg)
+	require.Error(t, err)
+
+	cfg.URL = ""
+	_, err = NewClient(ctx, cfg, cfg)
 	require.Error(t, err)
 }

--- a/tigris/collection_test.go
+++ b/tigris/collection_test.go
@@ -174,7 +174,7 @@ func TestCollectionBasic(t *testing.T) {
 	mtx.EXPECT().Commit(ctx)
 	mtx.EXPECT().Rollback(ctx)
 
-	db, err := openDatabaseFromModels(ctx, m, &config.Database{}, "db1", &Coll1{}, &Coll2{})
+	db, err := openDatabaseFromModels(ctx, m, &config.Client{}, "db1", &Coll1{}, &Coll2{})
 	require.NoError(t, err)
 
 	m.EXPECT().UseDatabase("db1").Return(mdb)
@@ -296,7 +296,7 @@ func TestCollection_Search(t *testing.T) {
 	mtx.EXPECT().Commit(ctx)
 	mtx.EXPECT().Rollback(ctx)
 
-	db, err := openDatabaseFromModels(ctx, m, &config.Database{}, "db1", &Coll1{})
+	db, err := openDatabaseFromModels(ctx, m, &config.Client{}, "db1", &Coll1{})
 	require.NoError(t, err)
 
 	m.EXPECT().UseDatabase("db1").Return(mdb)
@@ -553,7 +553,7 @@ func TestClientSchemaMigration(t *testing.T) {
 	ctx, cancel1 := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel1()
 
-	cfg := &config.Database{Driver: config.Driver{URL: test.GRPCURL(6)}}
+	cfg := &config.Client{Driver: config.Driver{URL: test.GRPCURL(6)}}
 	cfg.TLS = test.SetupTLS(t)
 
 	driver.DefaultProtocol = driver.GRPC
@@ -602,7 +602,7 @@ func TestClientSchemaMigration(t *testing.T) {
 			return &api.CommitTransactionResponse{}, nil
 		})
 
-	_, err = openDatabaseFromModels(ctx, drv, &config.Database{}, "db1", &testSchema1{})
+	_, err = openDatabaseFromModels(ctx, drv, &config.Client{}, "db1", &testSchema1{})
 	require.NoError(t, err)
 
 	mc.EXPECT().CreateDatabase(gomock.Any(),
@@ -648,7 +648,7 @@ func TestClientSchemaMigration(t *testing.T) {
 			return &api.CommitTransactionResponse{}, nil
 		})
 
-	_, err = openDatabaseFromModels(ctx, drv, &config.Database{}, "db1", &testSchema1{}, &testSchema2{})
+	_, err = openDatabaseFromModels(ctx, drv, &config.Client{}, "db1", &testSchema1{}, &testSchema2{})
 	require.NoError(t, err)
 
 	var m map[string]string
@@ -803,7 +803,7 @@ func TestOpenDatabase(t *testing.T) {
 
 	m.EXPECT().CreateDatabase(gomock.Any(), "db1")
 
-	db, err := openDatabaseFromModels(ctx, m, &config.Database{}, "db1")
+	db, err := openDatabaseFromModels(ctx, m, &config.Client{}, "db1")
 	require.NoError(t, err)
 	require.NotNil(t, db)
 }

--- a/tigris/database.go
+++ b/tigris/database.go
@@ -111,7 +111,7 @@ func (db *Database) createCollectionsFromSchemas(ctx context.Context, dbName str
 }
 
 // openDatabaseFromModels creates Database and collections from the provided collection models.
-func openDatabaseFromModels(ctx context.Context, d driver.Driver, cfg *config.Database, dbName string,
+func openDatabaseFromModels(ctx context.Context, d driver.Driver, cfg *config.Client, dbName string,
 	models ...schema.Model,
 ) (*Database, error) {
 	// optionally creates database if it's allowed
@@ -139,7 +139,7 @@ func openDatabaseFromModels(ctx context.Context, d driver.Driver, cfg *config.Da
 // OpenDatabase initializes Database from given collection models.
 // It creates Database if necessary.
 // Creates and migrates schemas of the collections which constitutes the Database.
-func OpenDatabase(ctx context.Context, cfg *config.Database, dbName string, models ...schema.Model,
+func OpenDatabase(ctx context.Context, cfg *config.Client, dbName string, models ...schema.Model,
 ) (*Database, error) {
 	if getTxCtx(ctx) != nil {
 		return nil, ErrNotTransactional
@@ -154,7 +154,7 @@ func OpenDatabase(ctx context.Context, cfg *config.Database, dbName string, mode
 }
 
 // DropDatabase deletes the database and all collections in it.
-func DropDatabase(ctx context.Context, cfg *config.Database, dbName string) error {
+func DropDatabase(ctx context.Context, cfg *config.Client, dbName string) error {
 	if getTxCtx(ctx) != nil {
 		return ErrNotTransactional
 	}

--- a/tigris/example_test.go
+++ b/tigris/example_test.go
@@ -31,7 +31,7 @@ func ExampleDatabase_Tx() {
 		Key1 string `tigris:"primary_key"`
 	}
 
-	db, err := OpenDatabase(ctx, &config.Database{}, "db1", &Coll1{})
+	db, err := OpenDatabase(ctx, &config.Client{}, "db1", &Coll1{})
 	if err != nil {
 		panic(err)
 	}
@@ -64,7 +64,7 @@ func ExampleOpenDatabase() {
 	// Connects to the Tigris server. Creates or opens database "db1".
 	// Creates or migrate &Coll1{}. Returns a "db" object, which provides
 	// access to the collections of the database, Coll1 in this example.
-	db, err := OpenDatabase(ctx, &config.Database{}, "db1", &Coll1{})
+	db, err := OpenDatabase(ctx, &config.Client{}, "db1", &Coll1{})
 	if err != nil {
 		panic(err)
 	}
@@ -83,7 +83,7 @@ func ExampleIterator() {
 		Key1 string `tigris:"primary_key"`
 	}
 
-	db, err := OpenDatabase(ctx, &config.Database{}, "db1", &Coll1{})
+	db, err := OpenDatabase(ctx, &config.Client{}, "db1", &Coll1{})
 	if err != nil {
 		panic(err)
 	}
@@ -114,7 +114,7 @@ func ExampleError() {
 		Key1 string `tigris:"primary_key"`
 	}
 
-	db, err := OpenDatabase(ctx, &config.Database{}, "db1", &Coll1{})
+	db, err := OpenDatabase(ctx, &config.Client{}, "db1", &Coll1{})
 	if err != nil {
 		panic(err)
 	}

--- a/tigris/topic_test.go
+++ b/tigris/topic_test.go
@@ -63,7 +63,7 @@ func TestTopicBasic(t *testing.T) {
 	mtx.EXPECT().Commit(ctx)
 	mtx.EXPECT().Rollback(ctx)
 
-	db, err := openDatabaseFromModels(ctx, m, &config.Database{}, "db1", &Coll1{})
+	db, err := openDatabaseFromModels(ctx, m, &config.Client{}, "db1", &Coll1{})
 	require.NoError(t, err)
 
 	m.EXPECT().BeginTx(gomock.Any(), "db1").Return(mtx, nil)


### PR DESCRIPTION
* No code configuration required by default, Default config points to Tigris hosted platform
* Parse client_id/client_secret/token from URL
* Take precedence into account: Default -> Environment -> Config strruct -> URL