### PR TITLE
fix: panic when database has no collections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+.vscode

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -1101,6 +1101,14 @@ func testTxBasicNegative(t *testing.T, c Driver, mc *mock.MockTigrisServer) {
 
 	err = tx.Rollback(ctx)
 	require.Error(t, err)
+
+	mc.EXPECT().DescribeDatabase(gomock.Any(),
+		pm(&api.DescribeDatabaseRequest{
+			Db: "db1",
+		})).Return(&api.DescribeDatabaseResponse{}, nil)
+
+	_, err = c.DescribeDatabase(ctx, "db1", nil)
+	require.NoError(t, err)
 }
 
 func TestTxGRPCDriverNegative(t *testing.T) {

--- a/driver/http.go
+++ b/driver/http.go
@@ -317,6 +317,10 @@ func (c *httpDriver) describeDatabaseWithOptions(ctx context.Context, db string,
 	r.Db = PtrToString(d.Db)
 	r.Size = PtrToInt64(d.Size)
 
+	if d.Collections == nil {
+		return &r, nil
+	}
+
 	for _, v := range *d.Collections {
 		r.Collections = append(r.Collections, &api.CollectionDescription{
 			Collection: PtrToString(v.Collection),


### PR DESCRIPTION
Fix collection dereferencing in `describeDatabaseWithOptions()` where the response may come back with empty `*d.Collections`.