### PR TITLE
Explicit schema version support

### DIFF
--- a/api/server/v1/header.go
+++ b/api/server/v1/header.go
@@ -29,6 +29,8 @@ const (
 	// values. For ex, 0.1 means 100milliseconds.
 	HeaderRequestTimeout = "Request-Timeout"
 
+	HeaderAccept = "Accept"
+
 	HeaderAccessControlAllowOrigin = "Access-Control-Allow-Origin"
 	HeaderAuthorization            = "authorization"
 
@@ -37,16 +39,19 @@ const (
 
 	HeaderPrefix = "Tigris-"
 
-	HeaderTxID          = "Tigris-Tx-Id"
-	HeaderTxOrigin      = "Tigris-Tx-Origin"
-	grpcGatewayPrefix   = "Grpc-Gateway-"
-	HeaderSchemaSignOff = "Tigris-Schema-Sign-Off"
+	HeaderTxID                      = "Tigris-Tx-Id"
+	HeaderTxOrigin                  = "Tigris-Tx-Origin"
+	grpcGatewayPrefix               = "Grpc-Gateway-"
+	HeaderSchemaSignOff             = "Tigris-Schema-Sign-Off"
+	HeaderSchemaVersion             = "Tigris-Schema-Version"
+	HeaderBypassAuthCache           = "Tigris-Bypass-Auth-Cache" // #nosec G101
+	HeaderReadSearchDataFromStorage = "Tigris-Search-Read-From-Storage"
 )
 
 func CustomMatcher(key string) (string, bool) {
 	key = textproto.CanonicalMIMEHeaderKey(key)
 	switch key {
-	case HeaderRequestTimeout, HeaderAccessControlAllowOrigin, SetCookie, Cookie:
+	case HeaderRequestTimeout, HeaderAccessControlAllowOrigin, SetCookie, Cookie, HeaderAccept:
 		return key, true
 	default:
 		if strings.HasPrefix(key, HeaderPrefix) {
@@ -62,4 +67,8 @@ func GetHeader(ctx context.Context, header string) string {
 	}
 
 	return metautils.ExtractIncoming(ctx).Get(grpcGatewayPrefix + header)
+}
+
+func GetNonGRPCGatewayHeader(ctx context.Context, header string) string {
+	return metautils.ExtractIncoming(ctx).Get(header)
 }

--- a/driver/grpc.go
+++ b/driver/grpc.go
@@ -124,6 +124,10 @@ func (c *grpcDriver) UseDatabase(project string) Database {
 		md = meta.Join(md, meta.Pairs(api.HeaderSchemaSignOff, "true"))
 	}
 
+	if len(HeaderSchemaVersionValue) > 0 {
+		md = meta.Join(md, meta.Pairs(api.HeaderSchemaVersion, HeaderSchemaVersionValue[0]))
+	}
+
 	return &driverCRUD{&grpcCRUD{db: project, branch: c.cfg.Branch, api: c.api, metadata: md}}
 }
 
@@ -277,6 +281,10 @@ func (c *grpcCRUD) beginTxWithOptions(ctx context.Context, options *TxOptions) (
 		for _, incomingCookie := range respHeaders.Get(SetCookieHeaderKey) {
 			md = meta.Join(md, meta.Pairs(CookieHeaderKey, incomingCookie))
 		}
+	}
+
+	if len(HeaderSchemaVersionValue) > 0 {
+		md = meta.Join(md, meta.Pairs(api.HeaderSchemaVersion, HeaderSchemaVersionValue[0]))
 	}
 
 	return &grpcCRUD{db: c.db, branch: c.branch, api: c.api, txCtx: resp.GetTxCtx(), metadata: md}, nil

--- a/driver/grpc_test.go
+++ b/driver/grpc_test.go
@@ -97,6 +97,7 @@ func TestGRPCHeaders(t *testing.T) {
 	defer cancel()
 
 	testSchemaSignOffHeader(t, mc, c)
+	testSchemaVersion(t, mc, c)
 }
 
 func TestNewDriverGRPC(t *testing.T) {

--- a/driver/http.go
+++ b/driver/http.go
@@ -189,6 +189,7 @@ func setHeaders(ctx context.Context, req *http.Request) error {
 	req.Header["Host"] = []string{req.Host}
 	req.Header["User-Agent"] = []string{UserAgent}
 	req.Header["Accept"] = []string{"*/*"}
+	req.Header[api.HeaderSchemaVersion] = HeaderSchemaVersionValue
 
 	if v := ctx.Value(txCtxKey{}); v != nil {
 		txCtx := v.(*api.TransactionCtx)

--- a/driver/http_test.go
+++ b/driver/http_test.go
@@ -64,6 +64,7 @@ func TestHTTPHeaders(t *testing.T) {
 	defer cancel()
 
 	testSchemaSignOffHeader(t, mc, c)
+	testSchemaVersion(t, mc, c)
 }
 
 func TestHTTPError(t *testing.T) {

--- a/driver/internal.go
+++ b/driver/internal.go
@@ -16,6 +16,7 @@ package driver
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -149,4 +150,8 @@ func PtrToInt32(b *int32) int32 {
 		return 0
 	}
 	return *b
+}
+
+func SetSchemaVersion(v int) {
+	HeaderSchemaVersionValue = []string{fmt.Sprintf("%d", v)}
 }

--- a/driver/types.go
+++ b/driver/types.go
@@ -34,8 +34,8 @@ const (
 	EnvProject      = "TIGRIS_PROJECT"
 	EnvDBBranch     = "TIGRIS_DB_BRANCH"
 
-	Version   = "v1.0.0"
-	UserAgent = "tigris-client-go/" + Version
+	ClientVersion = "v1.0.0"
+	UserAgent     = "tigris-client-go/" + ClientVersion
 
 	tokenRequestTimeout = 15 * time.Second
 )
@@ -46,6 +46,8 @@ var (
 
 	// TokenURLOverride Only used in tests to point auth to proper HTTP port in GRPC tests.
 	TokenURLOverride string
+
+	HeaderSchemaVersionValue []string
 )
 
 type (

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -17,6 +17,7 @@ package schema
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 	"testing"
 	"time"
 
@@ -391,18 +392,21 @@ func TestCollectionSchema(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(reflect.TypeOf(c.input).Name(), func(t *testing.T) {
-			schema, err := fromCollectionModel(c.input, Documents)
-			assert.Equal(t, c.err, err)
+			schema, err := fromCollectionModel(3, c.input, Documents)
+			require.Equal(t, c.err, err)
 			if schema != nil {
 				assert.Equal(t, Documents, schema.CollectionType)
 				c.output.CollectionType = Documents
+
+				assert.Equal(t, 3, schema.Version)
+				schema.Version = 0
+				assert.Equal(t, c.output, schema)
 			}
-			assert.Equal(t, c.output, schema)
 		})
 	}
 
 	t.Run("build", func(t *testing.T) {
-		s, err := fromCollectionModel(allTypes{}, Documents)
+		s, err := fromCollectionModel(5, allTypes{}, Documents)
 		require.NoError(t, err)
 
 		assert.Equal(t, Documents, s.CollectionType)
@@ -411,21 +415,21 @@ func TestCollectionSchema(t *testing.T) {
 		b, err := s.Build()
 		require.NoError(t, err)
 
-		require.Equal(t, `{"title":"all_types","properties":{"PtrStruct":{"type":"object","properties":{"ss_field_1":{"type":"string"}}},"Tm":{"type":"string","format":"date-time"},"TmPtr":{"type":"string","format":"date-time"},"UUID":{"type":"string","format":"uuid"},"UUIDPtr":{"type":"string","format":"uuid"},"arr_1":{"type":"array","items":{"type":"string"},"maxItems":3},"bool_1":{"type":"boolean"},"bool_123":{"type":"boolean"},"bytes_1":{"type":"string","format":"byte"},"bytes_2":{"type":"string","format":"byte"},"data_1":{"type":"object","properties":{"Nested":{"type":"object","properties":{"ss_field_1":{"type":"string"}}},"field_1":{"type":"string"}}},"float_32":{"type":"number"},"float_64":{"type":"number"},"int_1":{"type":"integer"},"int_32":{"type":"integer","format":"int32"},"int_64":{"type":"integer"},"map_1":{"type":"object","additionalProperties":true},"map_2":{"type":"object","additionalProperties":true},"map_any":{"type":"object","additionalProperties":true},"slice_1":{"type":"array","items":{"type":"string"}},"slice_2":{"type":"array","items":{"type":"object","properties":{"Nested":{"type":"object","properties":{"ss_field_1":{"type":"string"}}},"field_1":{"type":"string"}}}},"string_1":{"type":"string"}},"primary_key":["string_1"]}`, string(b))
+		require.Equal(t, `{"version":5,"title":"all_types","properties":{"PtrStruct":{"type":"object","properties":{"ss_field_1":{"type":"string"}}},"Tm":{"type":"string","format":"date-time"},"TmPtr":{"type":"string","format":"date-time"},"UUID":{"type":"string","format":"uuid"},"UUIDPtr":{"type":"string","format":"uuid"},"arr_1":{"type":"array","items":{"type":"string"},"maxItems":3},"bool_1":{"type":"boolean"},"bool_123":{"type":"boolean"},"bytes_1":{"type":"string","format":"byte"},"bytes_2":{"type":"string","format":"byte"},"data_1":{"type":"object","properties":{"Nested":{"type":"object","properties":{"ss_field_1":{"type":"string"}}},"field_1":{"type":"string"}}},"float_32":{"type":"number"},"float_64":{"type":"number"},"int_1":{"type":"integer"},"int_32":{"type":"integer","format":"int32"},"int_64":{"type":"integer"},"map_1":{"type":"object","additionalProperties":true},"map_2":{"type":"object","additionalProperties":true},"map_any":{"type":"object","additionalProperties":true},"slice_1":{"type":"array","items":{"type":"string"}},"slice_2":{"type":"array","items":{"type":"object","properties":{"Nested":{"type":"object","properties":{"ss_field_1":{"type":"string"}}},"field_1":{"type":"string"}}}},"string_1":{"type":"string"}},"primary_key":["string_1"]}`, string(b))
 	})
 
 	t.Run("multiple_models", func(t *testing.T) {
-		s, err := FromCollectionModels(Documents, pk{}, pk1{})
+		s, err := FromCollectionModels(7, Documents, pk{}, pk1{})
 		require.NoError(t, err)
 
 		assert.Equal(t, map[string]*Schema{
-			"pks":  {Name: "pks", Fields: map[string]*Field{"key_1": {Type: typeString}}, PrimaryKey: []string{"key_1"}, CollectionType: Documents},
-			"pk_1": {Name: "pk_1", Fields: map[string]*Field{"key_1": {Type: typeString}}, PrimaryKey: []string{"key_1"}, CollectionType: Documents},
+			"pks":  {Version: 7, Name: "pks", Fields: map[string]*Field{"key_1": {Type: typeString}}, PrimaryKey: []string{"key_1"}, CollectionType: Documents},
+			"pk_1": {Version: 7, Name: "pk_1", Fields: map[string]*Field{"key_1": {Type: typeString}}, PrimaryKey: []string{"key_1"}, CollectionType: Documents},
 		}, s)
 	})
 
 	t.Run("duplicate_pk_index", func(t *testing.T) {
-		_, err := FromCollectionModels(Documents, pkDup{})
+		_, err := FromCollectionModels(9, Documents, pkDup{})
 		if err.Error() == "duplicate primary key index 1 set for key_1 and key_2" {
 			require.Equal(t, err, fmt.Errorf("duplicate primary key index 1 set for key_1 and key_2"))
 		} else {
@@ -465,13 +469,14 @@ func TestTags(t *testing.T) {
 		FieldDefaultUUID uuid.UUID `json:"def_uuid" tigris:"default:uuid()"`
 	}
 
-	schema, err := fromCollectionModel(TestDefaults{}, Documents)
+	schema, err := fromCollectionModel(11, TestDefaults{}, Documents)
 	assert.Equal(t, nil, err)
 
 	b, err := schema.Build()
 	require.NoError(t, err)
 	exp := `{
 	"title":"test_defaults",
+	"version": 11,
 	"properties":{
 		"ID":{"type":"string","format":"uuid","autoGenerate":true},
 		"def_bool":{"type":"boolean","default":true},
@@ -546,9 +551,11 @@ func TestDatabaseSchema(t *testing.T) {
 		c2 *Coll2
 		c3 []Coll2
 		C4 []*Coll2 `json:"coll_4"`
+		c5 Coll2    `tigris:"- "`
+		c6 Coll2    `tigris:"version:5"`
 	}
 
-	_ = DB1{c1: Coll1{}, c2: &Coll2{}, c3: []Coll2{}, C4: []*Coll2{}}
+	_ = DB1{c1: Coll1{}, c2: &Coll2{}, c3: []Coll2{}, C4: []*Coll2{}, c5: Coll2{}, c6: Coll2{}}
 
 	type DB3 struct {
 		Coll1
@@ -559,13 +566,19 @@ func TestDatabaseSchema(t *testing.T) {
 		int64
 	}
 
+	type DB5 struct {
+		c6 *Coll2 `tigris:"version:asdf"`
+	}
+
 	_ = DB4{1}
+	_ = DB5{c6: &Coll2{}}
 
 	coll1 := Schema{Name: "Coll1", Fields: map[string]*Field{"Key1": {Type: "integer"}}, PrimaryKey: []string{"Key1"}, CollectionType: Documents}
 	c1 := Schema{Name: "c1", Fields: map[string]*Field{"Key1": {Type: "integer"}}, PrimaryKey: []string{"Key1"}, CollectionType: Documents}
 	c2 := Schema{Name: "c2", Fields: map[string]*Field{"Key2": {Type: "integer"}}, PrimaryKey: []string{"Key2"}, CollectionType: Documents}
 	c3 := Schema{Name: "c3", Fields: map[string]*Field{"Key2": {Type: "integer"}}, PrimaryKey: []string{"Key2"}, CollectionType: Documents}
 	c4 := Schema{Name: "coll_4", Fields: map[string]*Field{"Key2": {Type: "integer"}}, PrimaryKey: []string{"Key2"}, CollectionType: Documents}
+	c6 := Schema{Version: 5, Name: "c6", Fields: map[string]*Field{"Key2": {Type: "integer"}}, PrimaryKey: []string{"Key2"}, CollectionType: Documents}
 
 	var i int64
 
@@ -575,10 +588,11 @@ func TestDatabaseSchema(t *testing.T) {
 		output map[string]*Schema
 		err    error
 	}{
-		{DB1{}, "DB1", map[string]*Schema{"c1": &c1, "c2": &c2, "c3": &c3, "coll_4": &c4}, nil},
+		{DB1{}, "DB1", map[string]*Schema{"c1": &c1, "c2": &c2, "c3": &c3, "coll_4": &c4, "c6": &c6}, nil},
 		{&DB3{}, "DB3", map[string]*Schema{"Coll1": &coll1}, nil},
 		{DB4{}, "", nil, fmt.Errorf("model should be of struct type, not int64")},
 		{i, "", nil, fmt.Errorf("database model should be of struct type containing collection models types as fields")},
+		{DB5{}, "", nil, &strconv.NumError{Func: "Atoi", Num: "asdf", Err: strconv.ErrSyntax}},
 	}
 	for _, c := range cases {
 		t.Run(reflect.TypeOf(c.input).Name(), func(t *testing.T) {

--- a/search/search.go
+++ b/search/search.go
@@ -49,7 +49,7 @@ func NewSearch(name string, search driver.SearchClient) *Search {
 // This method is only needed if indexes need to be created dynamically,
 // all static indexes are created by OpenSearch.
 func (s *Search) CreateIndexes(ctx context.Context, model schema.Model, models ...schema.Model) error {
-	schemas, err := schema.FromCollectionModels(schema.Search, model, models...)
+	schemas, err := schema.FromCollectionModels(0, schema.Search, model, models...)
 	if err != nil {
 		return fmt.Errorf("error parsing model schema: %w", err)
 	}

--- a/tigris/client.go
+++ b/tigris/client.go
@@ -29,6 +29,8 @@ import (
 
 const DefaultBranch = "main"
 
+var SchemaVersion int
+
 type Config struct {
 	TLS          *tls.Config `json:"tls,omitempty"`
 	ClientID     string      `json:"client_id,omitempty"`

--- a/tigris/client_test.go
+++ b/tigris/client_test.go
@@ -62,6 +62,10 @@ func TestClient(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, DefaultBranch, c.config.Branch)
 
+	cfg.Project = ""
+	_, err = NewClient(ctx, cfg)
+	require.Error(t, err)
+
 	_, err = c.OpenDatabase(setTxCtx(ctx, &Tx{}), &Coll1{})
 	require.Error(t, err)
 

--- a/tigris/collection_test.go
+++ b/tigris/collection_test.go
@@ -246,6 +246,16 @@ func TestCollectionBasic(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, &ExplainResponse{Collection: "coll_1", Sorting: "sort1"}, explain)
 
+	// test sorting options
+	mdb.EXPECT().Explain(ctx, "coll_1", driver.Filter(`{"Key1":{"$eq":"aaa"}}`),
+		driver.Projection(`{"f1":true}`),
+		&driver.ReadOptions{Skip: 10, Sort: []byte(`[{"sort1":"$asc"}]`)},
+	).Return(&driver.ExplainResponse{Collection: "coll_1", Sorting: "sort1"}, nil)
+	explain, err = c.Explain(ctx, filter.Eq("Key1", "aaa"), fields.Include("f1"),
+		&ReadOptions{Skip: 10, Sort: sort.Ascending("sort1")})
+	require.NoError(t, err)
+	require.Equal(t, &ExplainResponse{Collection: "coll_1", Sorting: "sort1"}, explain)
+
 	mdb.EXPECT().DropCollection(ctx, "coll_1")
 
 	err = c.Drop(ctx)
@@ -572,13 +582,13 @@ func TestClientSchemaMigration(t *testing.T) {
 	require.NoError(t, err)
 
 	var m map[string]string
-	_, err = schema.FromCollectionModels(schema.Documents, &m)
+	_, err = schema.FromCollectionModels(1, schema.Documents, &m)
 	require.Error(t, err)
 	_, _, err = schema.FromDatabaseModel(&m)
 	require.Error(t, err)
 
 	var i int
-	_, err = schema.FromCollectionModels(schema.Documents, &i)
+	_, err = schema.FromCollectionModels(1, schema.Documents, &i)
 	require.Error(t, err)
 	_, _, err = schema.FromDatabaseModel(&i)
 	require.Error(t, err)
@@ -603,6 +613,35 @@ func TestClientSchemaMigration(t *testing.T) {
 		pm(&api.CreateOrUpdateCollectionsRequest{
 			Project: "db1",
 			Schemas: [][]byte{[]byte(`{"title":"coll_1","properties":{"Key1":{"type":"string"}},"primary_key":["Key1"],"collection_type":"documents"}`)},
+			Options: &api.CollectionOptions{},
+		})).Do(func(ctx context.Context, r *api.CreateOrUpdateCollectionsRequest) {
+	}).Return(&api.CreateOrUpdateCollectionsResponse{}, nil)
+
+	db = MustOpenDatabase(ctx, cfg, &Coll1{})
+	require.NotNil(t, db)
+
+	SchemaVersion = 11
+	defer func() {
+		SchemaVersion = 0
+	}()
+
+	txCtx := &api.TransactionCtx{Id: "tx_id1", Origin: "origin_id1"}
+
+	mc.EXPECT().BeginTransaction(gomock.Any(),
+		pm(&api.BeginTransactionRequest{
+			Project: "db1",
+			Options: &api.TransactionOptions{},
+		})).Return(&api.BeginTransactionResponse{TxCtx: txCtx}, nil)
+
+	mc.EXPECT().CommitTransaction(gomock.Any(),
+		pm(&api.CommitTransactionRequest{
+			Project: "db1",
+		})).Return(&api.CommitTransactionResponse{}, nil)
+
+	mc.EXPECT().CreateOrUpdateCollections(gomock.Any(),
+		pm(&api.CreateOrUpdateCollectionsRequest{
+			Project: "db1",
+			Schemas: [][]byte{[]byte(`{"version":11,"title":"coll_1","properties":{"Key1":{"type":"string"}},"primary_key":["Key1"],"collection_type":"documents"}`)},
 			Options: &api.CollectionOptions{},
 		})).Do(func(ctx context.Context, r *api.CreateOrUpdateCollectionsRequest) {
 	}).Return(&api.CreateOrUpdateCollectionsResponse{}, nil)


### PR DESCRIPTION
Support for explicit schema specified by the user.

* Adds schema version as a field of generated JSON schema
* Pass schema version in every API header

Can be explicitly set like:
```
tigris.SchemaVersion = 5
```

or, preferrably by the build system:

```
go build -ldflags "-X 'github.com/tigrisdata/tigris/tigris.SchemaVersion=$(tigris schema version --next)'
```
when there is a conflict then the user just need to rebuild and redeploy, no code change required or manual schema increment.