### PR TITLE
Detect 'id' field as implicit primary key

### DIFF
--- a/driver/http.go
+++ b/driver/http.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//nolint:bodyclose
 package driver
 
 import (
@@ -703,8 +704,8 @@ type httpStreamReader struct {
 
 func (g *httpStreamReader) read() (Document, error) {
 	var res struct {
-		Result *apiHTTP.ReadResponse
-		Error  *api.ErrorDetails
+		Result *apiHTTP.ReadResponse `json:"result"`
+		Error  *api.ErrorDetails     `json:"error"`
 	}
 
 	if err := g.stream.Decode(&res); err != nil {
@@ -767,11 +768,11 @@ type httpSearchReader struct {
 func (g *httpSearchReader) read() (SearchResponse, error) {
 	var res struct {
 		Result struct {
-			Hits   []*api.SearchHit
-			Facets map[string]*api.SearchFacet
-			Meta   *api.SearchMetadata
-		}
-		Error *api.ErrorDetails
+			Hits   []*api.SearchHit            `json:"hits"`
+			Facets map[string]*api.SearchFacet `json:"facets"`
+			Meta   *api.SearchMetadata         `json:"meta"`
+		} `json:"result"`
+		Error *api.ErrorDetails `json:"error"`
 	}
 
 	if err := g.stream.Decode(&res); err != nil {

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -393,6 +393,8 @@ func fromCollectionModel(model interface{}, typ string) (*Schema, error) {
 		// add `ID uuid.UUID` if none found
 		if p, ok = sch.Fields["Id"]; ok {
 			name = "Id"
+		} else if p, ok = sch.Fields["id"]; ok {
+			name = "id"
 		} else if p, ok = sch.Fields[id]; !ok {
 			sch.Fields[id] = &Field{Type: typeString, Format: formatUUID, AutoGenerate: true}
 			p = sch.Fields[id]

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -160,6 +160,11 @@ func TestCollectionSchema(t *testing.T) {
 		ID time.Time
 	}
 
+	type autoID1 struct {
+		ID int64 `json:"id"`
+	}
+
+	// use annotated and not implied ID
 	type autoIDOverride struct {
 		RealID time.Time `tigris:"primaryKey,autoGenerate"`
 		ID     time.Time
@@ -360,6 +365,12 @@ func TestCollectionSchema(t *testing.T) {
 				"ID": {Type: typeString, Format: formatDateTime, AutoGenerate: true},
 			},
 			PrimaryKey: []string{"ID"},
+		}, nil},
+		{autoID1{}, &Schema{
+			Name: "auto_id_1", Fields: map[string]*Field{
+				"id": {Type: typeInteger, AutoGenerate: true},
+			},
+			PrimaryKey: []string{"id"},
 		}, nil},
 		{autoIDOverride{}, &Schema{
 			Name: "auto_id_overrides", Fields: map[string]*Field{

--- a/tigris/model_test.go
+++ b/tigris/model_test.go
@@ -134,12 +134,12 @@ func TestModelMetadata(t *testing.T) {
 
 	t.Run("all_types", func(t *testing.T) {
 		type Coll2 struct {
-			Int     int
-			Int64   int64
-			Time    time.Time
-			UUID    uuid.UUID
-			String  string
-			Float64 float64
+			Int     int       `json:"int"`
+			Int64   int64     `json:"int64"`
+			Time    time.Time `json:"time"`
+			UUID    uuid.UUID `json:"uuid"`
+			String  string    `json:"string"`
+			Float64 float64   `json:"float64"`
 		}
 
 		d3 := &Coll2{}


### PR DESCRIPTION
Before only 'ID' and 'Id' were detected.