### PR TITLE
Optionally skip schema validation

### DIFF
--- a/api/server/v1/header.go
+++ b/api/server/v1/header.go
@@ -1,0 +1,65 @@
+// Copyright 2022-2023 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"context"
+	"net/textproto"
+	"strings"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/util/metautils"
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+)
+
+const (
+	// HeaderRequestTimeout is an end-to-end request header that indicates the maximum time that a client is
+	// prepared to await a response. The value of the header is in seconds. A client is allowed to send fractional
+	// values. For ex, 0.1 means 100milliseconds.
+	HeaderRequestTimeout = "Request-Timeout"
+
+	HeaderAccessControlAllowOrigin = "Access-Control-Allow-Origin"
+	HeaderAuthorization            = "authorization"
+
+	SetCookie = "Set-Cookie"
+	Cookie    = "Cookie"
+
+	HeaderPrefix = "Tigris-"
+
+	HeaderTxID          = "Tigris-Tx-Id"
+	HeaderTxOrigin      = "Tigris-Tx-Origin"
+	grpcGatewayPrefix   = "Grpc-Gateway-"
+	HeaderSchemaSignOff = "Tigris-Schema-Sign-Off"
+)
+
+func CustomMatcher(key string) (string, bool) {
+	key = textproto.CanonicalMIMEHeaderKey(key)
+	switch key {
+	case HeaderRequestTimeout, HeaderAccessControlAllowOrigin, SetCookie, Cookie:
+		return key, true
+	default:
+		if strings.HasPrefix(key, HeaderPrefix) {
+			return key, true
+		}
+		return runtime.DefaultHeaderMatcher(key)
+	}
+}
+
+func GetHeader(ctx context.Context, header string) string {
+	if val := metautils.ExtractIncoming(ctx).Get(header); val != "" {
+		return val
+	}
+
+	return metautils.ExtractIncoming(ctx).Get(grpcGatewayPrefix + header)
+}

--- a/api/server/v1/tx.go
+++ b/api/server/v1/tx.go
@@ -17,46 +17,70 @@ package api
 import (
 	"context"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware/util/metautils"
 	"google.golang.org/grpc"
 )
 
-var (
-	HeaderPrefix   = "Tigris-"
-	HeaderTxID     = HeaderPrefix + "Tx-Id"
-	HeaderTxOrigin = HeaderPrefix + "Tx-Origin"
+const (
+	HealthMethodName = "/HealthAPI/Health"
 
-	grpcGatewayPrefix = "grpc-gateway-"
+	apiMethodPrefix = "/tigrisdata.v1.Tigris/"
+
+	InsertMethodName  = apiMethodPrefix + "Insert"
+	ReplaceMethodName = apiMethodPrefix + "Replace"
+	UpdateMethodName  = apiMethodPrefix + "Update"
+	DeleteMethodName  = apiMethodPrefix + "Delete"
+	ReadMethodName    = apiMethodPrefix + "Read"
+
+	SearchMethodName = apiMethodPrefix + "Search"
+
+	SubscribeMethodName = apiMethodPrefix + "Subscribe"
+
+	EventsMethodName = apiMethodPrefix + "Events"
+
+	CommitTransactionMethodName   = apiMethodPrefix + "CommitTransaction"
+	RollbackTransactionMethodName = apiMethodPrefix + "RollbackTransaction"
+
+	CreateOrUpdateCollectionMethodName = apiMethodPrefix + "CreateOrUpdateCollection"
+	DropCollectionMethodName           = apiMethodPrefix + "DropCollection"
+
+	DropDatabaseMethodName = apiMethodPrefix + "DropDatabase"
+
+	ListDatabasesMethodName   = apiMethodPrefix + "ListDatabases"
+	ListCollectionsMethodName = apiMethodPrefix + "ListCollections"
+
+	DescribeDatabaseMethodName   = apiMethodPrefix + "DescribeDatabase"
+	DescribeCollectionMethodName = apiMethodPrefix + "DescribeCollection"
+
+	ObservabilityMethodPrefix    = "/tigrisdata.observability.v1.Observability/"
+	ManagementMethodPrefix       = "/tigrisdata.management.v1.Management/"
+	CreateNamespaceMethodName    = ManagementMethodPrefix + "CreateNamespace"
+	ListNamespaceMethodName      = ManagementMethodPrefix + "ListNamespaces"
+	DescribeNamespacesMethodName = ManagementMethodPrefix + "DescribeNamespaces"
+
+	AuthMethodPrefix         = "/tigrisdata.auth.v1.Auth/"
+	GetAccessTokenMethodName = AuthMethodPrefix + "GetAccessToken"
 )
 
 func IsTxSupported(ctx context.Context) bool {
 	m, _ := grpc.Method(ctx)
 	switch m {
-	case "Insert", "Replace", "Update", "Delete", "Read",
-		"CreateOrUpdateCollection", "DropCollection", "ListCollections":
+	case InsertMethodName, ReplaceMethodName, UpdateMethodName, DeleteMethodName, ReadMethodName,
+		CommitTransactionMethodName, RollbackTransactionMethodName,
+		DropCollectionMethodName, ListCollectionsMethodName, CreateOrUpdateCollectionMethodName:
 		return true
 	default:
 		return false
 	}
 }
 
-func getHeader(ctx context.Context, header string) string {
-	if val := metautils.ExtractIncoming(ctx).Get(header); val != "" {
-		return val
-	}
-
-	return metautils.ExtractIncoming(ctx).Get(grpcGatewayPrefix + header)
-}
-
 func GetTransaction(ctx context.Context) *TransactionCtx {
-	tx := &TransactionCtx{
-		Id:     getHeader(ctx, HeaderTxID),
-		Origin: getHeader(ctx, HeaderTxOrigin),
+	origin := GetHeader(ctx, HeaderTxOrigin)
+	if len(origin) == 0 {
+		return nil
 	}
 
-	if tx.Id != "" {
-		return tx
+	return &TransactionCtx{
+		Id:     GetHeader(ctx, HeaderTxID),
+		Origin: origin,
 	}
-
-	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -31,4 +31,6 @@ type Driver struct {
 	Protocol     string        `json:"protocol,omitempty"`
 	DisablePing  bool          `json:"disable_ping,omitempty"`
 	PingInterval time.Duration `json:"ping_interval_ms,omitempty"`
+
+	SkipSchemaValidation bool `json:"skip_schema_validation,omitempty"`
 }

--- a/tigris/client.go
+++ b/tigris/client.go
@@ -57,6 +57,8 @@ func driverConfig(cfg *Config) *config.Driver {
 		Branch:       cfg.Branch,
 		Token:        cfg.Token,
 		Protocol:     cfg.Protocol,
+
+		SkipSchemaValidation: true,
 	}
 }
 


### PR DESCRIPTION
By default disable schema validation from high level client, where data comes from user models.