### PR TITLE
Idiomatic projections

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/tigrisdata/tigris-client-go
 go 1.18
 
 require (
+	github.com/buger/jsonparser v1.1.1
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deepmap/oapi-codegen v1.12.4
 	github.com/fullstorydev/grpchan v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,7 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
+github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -269,6 +269,12 @@ func setRequired(fields map[string]*Field) []string {
 	return req
 }
 
+// SimpleType returns true if type marshals to primitive JSON types: string, bool, number.
+func SimpleType(t reflect.Type) bool {
+	return t.PkgPath() == "time" && t.Name() == "Time" ||
+		t.PkgPath() == "github.com/google/uuid" && t.Name() == "UUID"
+}
+
 // traverseFields recursively parses the model structure and build the schema structure out of it.
 func traverseFields(prefix string, t reflect.Type, fields map[string]*Field, pk map[string]int, nFields *int) error {
 	if prefix != "" {
@@ -343,7 +349,11 @@ func traverseFields(prefix string, t reflect.Type, fields map[string]*Field, pk 
 
 			f.Required = setRequired(f.Fields)
 		} else if f.Type == typeArray {
-			if field.Type.Elem().Kind() == reflect.Struct {
+			if tp.Elem().Kind() == reflect.Ptr {
+				tp = tp.Elem()
+			}
+
+			if tp.Elem().Kind() == reflect.Struct {
 				f.Items = &Field{
 					// Name:   tp.Elem().Name(),
 					Type:   typeObject,

--- a/tigris/projection.go
+++ b/tigris/projection.go
@@ -1,0 +1,303 @@
+// Copyright 2022-2023 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tigris
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/buger/jsonparser"
+	api "github.com/tigrisdata/tigris-client-go/api/server/v1"
+	"github.com/tigrisdata/tigris-client-go/driver"
+	"github.com/tigrisdata/tigris-client-go/fields"
+	"github.com/tigrisdata/tigris-client-go/filter"
+	"github.com/tigrisdata/tigris-client-go/schema"
+)
+
+type Projection[T schema.Model, P schema.Model] struct {
+	coll       *Collection[T]
+	projection driver.Projection
+	err        error
+	keyPath    []string
+}
+
+func findSubType(t reflect.Type, keyPath []string) (reflect.Type, error) {
+	for _, v := range keyPath {
+		found := false
+		for i := 0; i < t.NumField(); i++ {
+			field := t.Field(i)
+
+			fName := fieldName(field)
+
+			tp := field.Type
+			if tp.Kind() == reflect.Ptr {
+				tp = tp.Elem()
+			}
+
+			if tp.Kind() == reflect.Slice || tp.Kind() == reflect.Array {
+				tp = tp.Elem()
+				if tp.Kind() == reflect.Ptr {
+					tp = tp.Elem()
+				}
+			}
+
+			if tp.Kind() == reflect.Struct {
+				if fName == v {
+					t = tp
+					found = true
+					break
+				}
+			}
+		}
+		if !found {
+			return nil, fmt.Errorf("no subobject found for key path %+v", keyPath)
+		}
+	}
+
+	return t, nil
+}
+
+// GetProjection returns collection object corresponding to collection model T.
+func GetProjection[T schema.Model, P schema.Model](db *Database, keyPath ...string) *Projection[T, P] {
+	var (
+		m T
+		p P
+	)
+
+	name := schema.ModelName(&m)
+	prefix := strings.Join(keyPath, ".")
+	pt := &Projection[T, P]{coll: getNamedCollection[T](db, name)}
+
+	t, err := findSubType(reflect.TypeOf(m), keyPath)
+	if err != nil {
+		pt.err = fmt.Errorf("no subobject found for key path %+v", keyPath)
+		return pt
+	}
+
+	pt.keyPath = keyPath
+
+	// TODO: Cache marshaled projections
+	include := fields.ReadBuilder()
+	_, pt.err = flattenType(prefix, t, reflect.TypeOf(p), include)
+	if pt.err != nil {
+		return pt
+	}
+
+	_, pt.err = include.Build()
+	if pt.err != nil {
+		return pt
+	}
+
+	pt.projection = include.Built()
+
+	// All the fields under the prefix is included
+	if string(pt.projection) == `{}` && len(prefix) > 0 {
+		include = fields.ReadBuilder()
+		include.Include(prefix)
+		_, pt.err = include.Build()
+		pt.projection = include.Built()
+	}
+
+	return pt
+}
+
+// Read returns documents which satisfies the filter.
+// Only field from the give fields are populated in the documents. By default, all fields are populated.
+func (p *Projection[T, P]) Read(ctx context.Context, filter filter.Filter) (*Iterator[P], error) {
+	if p.err != nil {
+		return nil, p.err
+	}
+
+	f, err := filter.Build()
+	if err != nil {
+		return nil, err
+	}
+
+	it, err := getDB(ctx, p.coll.db).Read(ctx, p.coll.name, f, p.projection)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Iterator[P]{Iterator: it, unmarshaler: p.projectionUnmarshal}, nil
+}
+
+// ReadAll reads all the documents from the collection.
+func (p *Projection[T, P]) ReadAll(ctx context.Context) (*Iterator[P], error) {
+	if p.err != nil {
+		return nil, p.err
+	}
+
+	it, err := getDB(ctx, p.coll.db).Read(ctx, p.coll.name, driver.Filter(`{}`), p.projection)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Iterator[P]{Iterator: it, unmarshaler: p.projectionUnmarshal}, nil
+}
+
+// ReadWithOptions returns specific fields of the documents according to the filter.
+// It allows further configure returned documents by providing options:
+//
+//	Limit - only returned first "Limit" documents from the result
+//	Skip - start returning documents after skipping "Skip" documents from the result
+func (p *Projection[T, P]) ReadWithOptions(ctx context.Context, filter filter.Filter, options *ReadOptions) (*Iterator[P], error) {
+	if p.err != nil {
+		return nil, p.err
+	}
+
+	f, err := filter.Build()
+	if err != nil {
+		return nil, err
+	}
+	if options == nil {
+		return nil, fmt.Errorf("API expecting options but received null")
+	}
+
+	it, err := getDB(ctx, p.coll.db).Read(ctx, p.coll.name, f, p.projection, &driver.ReadOptions{
+		Limit:     options.Limit,
+		Skip:      options.Skip,
+		Offset:    options.Offset,
+		Collation: (*api.Collation)(options.Collation),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &Iterator[P]{Iterator: it, unmarshaler: p.projectionUnmarshal}, nil
+}
+
+func fieldName(field reflect.StructField) string {
+	fName := strings.Split(field.Tag.Get("json"), ",")[0]
+
+	// Obey JSON skip tag
+	// and skip unexported fields
+	if strings.Compare(fName, "-") == 0 || !field.IsExported() {
+		return ""
+	}
+
+	if strings.Trim(field.Tag.Get("tigris"), " ") == "-" {
+		return ""
+	}
+
+	// Use json name if it's defined
+	if fName == "" && !field.Anonymous {
+		fName = field.Name
+	}
+
+	return fName
+}
+
+func flattenType(prefix string, d reflect.Type, p reflect.Type, fields *fields.Read) (bool, error) {
+	if prefix != "" {
+		prefix += "."
+	}
+
+	docFields := make(map[string]reflect.Type)
+	for i := 0; i < d.NumField(); i++ {
+		fn := fieldName(d.Field(i))
+
+		dp := d.Field(i).Type
+		if dp.Kind() == reflect.Ptr {
+			dp = dp.Elem()
+		}
+
+		docFields[fn] = dp
+	}
+
+	if p.Kind() == reflect.Slice || p.Kind() == reflect.Array {
+		p = p.Elem()
+		if p.Kind() == reflect.Ptr {
+			p = p.Elem()
+		}
+	}
+
+	incomplete := make(map[string]bool)
+	for i := 0; i < p.NumField(); i++ {
+		field := p.Field(i)
+
+		fName := fieldName(field)
+
+		pft := field.Type
+		if pft.Kind() == reflect.Ptr {
+			pft = pft.Elem()
+		}
+
+		dft, ok := docFields[fName]
+		if !ok {
+			return false, fmt.Errorf("field present in projection and doesn't exist in the document: %s", prefix+fName)
+		}
+
+		if dft.Kind() == reflect.Ptr {
+			dft = dft.Elem()
+		}
+
+		if pft.Kind() != dft.Kind() {
+			return false, fmt.Errorf("projection type mismatch. doc=%s, projection=%s", dft.Kind(), pft.Kind())
+		}
+
+		if pft.Kind() == reflect.Slice || pft.Kind() == reflect.Array {
+			pft = pft.Elem()
+			dft = dft.Elem()
+			if pft.Kind() == reflect.Ptr {
+				pft = pft.Elem()
+			}
+			if dft.Kind() == reflect.Ptr {
+				dft = dft.Elem()
+			}
+		}
+
+		if pft.Kind() == reflect.Struct && !schema.SimpleType(pft) {
+			i, err := flattenType(prefix+fName, dft, pft, fields)
+			if err != nil {
+				return false, err
+			}
+			if i {
+				incomplete[prefix+fName] = true
+			}
+		}
+
+		delete(docFields, fName)
+	}
+
+	if len(docFields) > 0 || len(incomplete) > 0 {
+		for i := 0; i < p.NumField(); i++ {
+			fName := fieldName(p.Field(i))
+
+			if !incomplete[prefix+fName] {
+				fields.Include(prefix + fName)
+			}
+		}
+
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func (p *Projection[T, P]) projectionUnmarshal(b []byte, v *P) error {
+	if len(p.keyPath) > 0 {
+		sub, _, _, err := jsonparser.Get(b, p.keyPath...)
+		if err != nil {
+			return err
+		}
+
+		return json.Unmarshal(sub, v)
+	}
+
+	return json.Unmarshal(b, v)
+}

--- a/tigris/projection_test.go
+++ b/tigris/projection_test.go
@@ -1,0 +1,383 @@
+// Copyright 2022-2023 Tigris Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tigris
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/tigrisdata/tigris-client-go/driver"
+	"github.com/tigrisdata/tigris-client-go/filter"
+	"github.com/tigrisdata/tigris-client-go/mock"
+)
+
+func TestProjectionBasic(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	ctrl := gomock.NewController(t)
+	m := mock.NewMockDriver(ctrl)
+
+	type Address struct {
+		Street  string
+		City    string
+		State   string
+		Zipcode string
+	}
+
+	type Account struct {
+		Name        string
+		Balance     string
+		BankAddress *Address
+	}
+
+	type Assets struct {
+		Accounts []*Account
+	}
+
+	type User struct {
+		Name           string
+		Address        Address
+		MailingAddress Address `json:"mailing_address"`
+		Assets         Assets
+		CreatedAt      time.Time
+		UUID           uuid.UUID
+	}
+
+	type UserName struct {
+		Name string
+	}
+
+	type DiagonalProjection struct {
+		Assets struct {
+			Accounts []struct {
+				Balance string
+			}
+		}
+		Address struct {
+			State string
+		}
+	}
+
+	type NestedProjection struct {
+		Assets struct {
+			Accounts []struct {
+				Name        string
+				Balance     string
+				BankAddress struct {
+					Street string
+				}
+			}
+		}
+		Address struct {
+			State string
+		}
+	}
+
+	type FieldNotInDoc struct {
+		NoSuchField string
+	}
+
+	type FieldTypeMismatch struct {
+		Name float64
+	}
+
+	mdb := mock.NewMockDatabase(ctrl)
+	mtx := mock.NewMockTx(ctrl)
+
+	m.EXPECT().UseDatabase("db1").Return(mdb).Times(2)
+	mdb.EXPECT().BeginTx(gomock.Any()).Return(mtx, nil)
+	mtx.EXPECT().CreateOrUpdateCollection(gomock.Any(), "users",
+		jm(t, `
+{
+	"title":"users",
+	"properties":
+	{ 
+		"Address": {
+			"type":"object",
+			"properties":{
+				"City":{"type":"string"},
+				"State":{"type":"string"},
+				"Street":{"type":"string"},
+				"Zipcode":{"type":"string"}
+			}
+		},
+		"Assets": {
+			"type":"object",
+			"properties":{
+				"Accounts":{
+					"type":"array",
+					"items":{
+						"type":"object",
+						"properties":{
+							"BankAddress": {
+								"type":"object",
+								"properties":{
+									"City":{"type":"string"},
+									"State":{"type":"string"},
+									"Street":{"type":"string"},
+									"Zipcode":{"type":"string"}
+								}
+							},
+							"Balance":{"type":"string"},
+							"Name":{"type":"string"}
+						}
+					}
+				}
+			}
+		},
+		"CreatedAt":{"type":"string","format":"date-time"},
+		"ID":{"type":"string","format":"uuid","autoGenerate":true},
+		"Name":{"type":"string"},
+		"UUID":{"type":"string","format":"uuid"},
+		"mailing_address":{
+			"type":"object",
+			"properties":{
+				"City":{"type":"string"},
+				"State":{"type":"string"},
+				"Street":{"type":"string"},
+				"Zipcode":{"type":"string"}
+			}
+		}
+	},
+	"primary_key":["ID"],
+	"collection_type":"documents"
+}`))
+
+	mtx.EXPECT().Commit(ctx)
+	mtx.EXPECT().Rollback(ctx)
+
+	db, err := TestOpenDatabase(ctx, m, "db1", &User{})
+	require.NoError(t, err)
+
+	pt := GetProjection[User, Address](db, "mailing_address")
+	require.NoError(t, pt.err)
+	require.Equal(t, `{"mailing_address":true}`, string(pt.projection))
+
+	m.EXPECT().UseDatabase("db1").Return(mdb).Times(1)
+	pt1 := GetProjection[User, UserName](db)
+	require.NoError(t, pt1.err)
+	require.Equal(t, `{"Name":true}`, string(pt1.projection))
+
+	m.EXPECT().UseDatabase("db1").Return(mdb).Times(1)
+	pt2 := GetProjection[User, DiagonalProjection](db)
+	require.NoError(t, pt2.err)
+	require.JSONEq(t, `{"Address.State":true,"Assets.Accounts.Balance":true}`, string(pt2.projection))
+
+	m.EXPECT().UseDatabase("db1").Return(mdb).Times(1)
+	pt3 := GetProjection[User, DiagonalProjection](db, "invalid_path")
+	require.Equal(t, fmt.Errorf("no subobject found for key path [invalid_path]"), pt3.err)
+
+	m.EXPECT().UseDatabase("db1").Return(mdb).Times(1)
+	pt3 = GetProjection[User, DiagonalProjection](db, "invalid_path", "nested_invalid")
+	require.Error(t, fmt.Errorf("no subobject found for key path [invalid_path]"), pt3.err)
+
+	m.EXPECT().UseDatabase("db1").Return(mdb).Times(1)
+	pt33 := GetProjection[User, FieldNotInDoc](db)
+	require.Equal(t, fmt.Errorf("field present in projection and doesn't exist in the document: NoSuchField"), pt33.err)
+
+	m.EXPECT().UseDatabase("db1").Return(mdb).Times(1)
+	pt34 := GetProjection[User, FieldTypeMismatch](db)
+	require.Equal(t, fmt.Errorf("projection type mismatch. doc=string, projection=float64"), pt34.err)
+
+	m.EXPECT().UseDatabase("db1").Return(mdb).Times(1)
+	pt4 := GetProjection[User, []Account](db, "Assets", "Accounts")
+	require.NoError(t, pt4.err)
+	require.Equal(t, `{"Assets.Accounts":true}`, string(pt4.projection))
+
+	m.EXPECT().UseDatabase("db1").Return(mdb).Times(1)
+	pt5 := GetProjection[User, NestedProjection](db)
+	require.NoError(t, pt5.err)
+	require.JSONEq(t, `{"Address.State":true, "Assets.Accounts.Balance":true, "Assets.Accounts.BankAddress.Street":true, "Assets.Accounts.Name":true}`, string(pt5.projection))
+
+	mit := mock.NewMockIterator(ctrl)
+
+	mdb.EXPECT().Read(ctx, "users",
+		driver.Filter(`{"$or":[{"Key1":{"$eq":"aaa"}},{"Key1":{"$eq":"ccc"}}]}`),
+		driver.Projection(`{"Assets.Accounts":true}`),
+	).Return(mit, nil)
+
+	it, err := pt4.Read(ctx, filter.Or(
+		filter.Eq("Key1", "aaa"),
+		filter.Eq("Key1", "ccc")),
+	)
+	require.NoError(t, err)
+
+	var (
+		d  []Account
+		dd driver.Document
+	)
+
+	usr := &User{
+		Assets: Assets{
+			Accounts: []*Account{
+				{
+					Name:        "name1",
+					Balance:     "balance1",
+					BankAddress: &Address{},
+				},
+			},
+		},
+	}
+
+	mit.EXPECT().Close()
+	mit.EXPECT().Next(&dd).SetArg(0, toDocument(t, usr)).Return(true)
+	mit.EXPECT().Next(&dd).Return(false)
+	mit.EXPECT().Err().Return(nil)
+
+	for it.Next(&d) {
+		require.Equal(t, []Account{
+			{
+				Name:        "name1",
+				Balance:     "balance1",
+				BankAddress: &Address{},
+			},
+		}, d)
+	}
+
+	require.NoError(t, it.Err())
+
+	it.Close()
+
+	mdb.EXPECT().Read(ctx, "users",
+		driver.Filter(`{"$or":[{"Key1":{"$eq":"aaa"}},{"Key1":{"$eq":"ccc"}}]}`),
+		driver.Projection(`{"Name":true}`),
+	).Return(mit, nil)
+
+	it1, err := pt1.Read(ctx, filter.Or(
+		filter.Eq("Key1", "aaa"),
+		filter.Eq("Key1", "ccc")),
+	)
+	require.NoError(t, err)
+
+	usr = &User{
+		Name: "user_name1",
+		Assets: Assets{
+			Accounts: []*Account{
+				{
+					Name:        "name1",
+					Balance:     "balance1",
+					BankAddress: &Address{},
+				},
+			},
+		},
+	}
+
+	mit.EXPECT().Close()
+	mit.EXPECT().Next(&dd).SetArg(0, toDocument(t, usr)).Return(true)
+	mit.EXPECT().Next(&dd).Return(false)
+	mit.EXPECT().Err().Return(nil)
+
+	var u UserName
+
+	for it1.Next(&u) {
+		require.Equal(t, usr.Name, u.Name)
+	}
+
+	require.NoError(t, it.Err())
+
+	it.Close()
+
+	mdb.EXPECT().Read(ctx, "users",
+		driver.Filter(`{"$or":[{"Key1":{"$eq":"aaa"}},{"Key1":{"$eq":"ccc"}}]}`),
+		driver.Projection(`{"mailing_address":true}`),
+	).Return(mit, nil)
+
+	it2, err := pt.Read(ctx, filter.Or(
+		filter.Eq("Key1", "aaa"),
+		filter.Eq("Key1", "ccc")),
+	)
+	require.NoError(t, err)
+
+	usr = &User{
+		Name: "user_name1",
+		Assets: Assets{
+			Accounts: []*Account{
+				{
+					Name:        "name1",
+					Balance:     "balance1",
+					BankAddress: &Address{},
+				},
+			},
+		},
+		MailingAddress: Address{
+			City:   "Palo Alto",
+			Street: "Louis Rd",
+		},
+	}
+
+	mit.EXPECT().Close()
+	mit.EXPECT().Next(&dd).SetArg(0, toDocument(t, usr)).Return(true)
+	mit.EXPECT().Next(&dd).Return(false)
+	mit.EXPECT().Err().Return(nil)
+
+	var ma Address
+
+	for it2.Next(&ma) {
+		require.Equal(t, usr.MailingAddress, ma)
+	}
+
+	require.NoError(t, it.Err())
+
+	it.Close()
+
+	mdb.EXPECT().Read(ctx, "users",
+		driver.Filter(`{}`),
+		driver.Projection(`{"mailing_address":true}`),
+	).Return(mit, nil)
+
+	it2, err = pt.ReadAll(ctx)
+	require.NoError(t, err)
+
+	mit.EXPECT().Close()
+	mit.EXPECT().Next(&dd).SetArg(0, toDocument(t, usr)).Return(true)
+	mit.EXPECT().Next(&dd).Return(false)
+	mit.EXPECT().Err().Return(nil)
+
+	for it2.Next(&ma) {
+		require.Equal(t, usr.MailingAddress, ma)
+	}
+
+	require.NoError(t, it.Err())
+
+	it.Close()
+
+	mdb.EXPECT().Read(ctx, "users",
+		driver.Filter(`{}`),
+		driver.Projection(`{"mailing_address":true}`),
+		&driver.ReadOptions{},
+	).Return(mit, nil)
+
+	it2, err = pt.ReadWithOptions(ctx, filter.All, &ReadOptions{})
+	require.NoError(t, err)
+
+	mit.EXPECT().Close()
+	mit.EXPECT().Next(&dd).SetArg(0, toDocument(t, usr)).Return(true)
+	mit.EXPECT().Next(&dd).Return(false)
+	mit.EXPECT().Err().Return(nil)
+
+	for it2.Next(&ma) {
+		require.Equal(t, usr.MailingAddress, ma)
+	}
+
+	require.NoError(t, it.Err())
+
+	it.Close()
+}


### PR DESCRIPTION
Instead of specifying fields to include/exclude in the collection read APIs, this PR
introduces typed projections.

Read result includes all the fields defined in the projection type.

Examples:
```
type Address struct {
  City string
  State string
  Street string
}

type User struct {
  ID uuid.UUID
  Name   string
  Address Address `json:"mailing_address"`
}

coll := GetCollection[User](db)

_, err = coll.Insert(ctx, &User{ID: "uuid1", Name: "John", Address: Address{City:
  "SF", State: "CA", Street: "Market"}})

proj := GetProjection[User, Address](db, "mailing_address")

it, err := proj.ReadAll(ctx)

var addr Address
for it.Next(&addr) {
  fmt.Printf("%+v\n", addr)
}

// Output:
// {City: "SF", State: "CA", Street: "Market"})

type UserName struct {
  ID uuid.UUID
  Name string
}

proj2 := GetProjection[User, UserName](db)

it2, err := proj2.ReadAll(ctx)

var un UserName
for it2.Next(&un) {
  fmt.Printf("%+v\n", un)
}

// Output:
// {ID: uuid1, Name: John}