### PR TITLE
Make using NewSortOrder optional

### DIFF
--- a/search/request.go
+++ b/search/request.go
@@ -63,7 +63,7 @@ type RequestBuilder interface {
 	WithFilter(filter.Filter) RequestBuilder
 	WithFacetFields(fields ...string) RequestBuilder
 	WithFacet(*FacetQuery) RequestBuilder
-	WithSorting(sortByFields ...sort.Sort) RequestBuilder
+	WithSorting(sortByFields ...sort.Order) RequestBuilder
 	WithSortOrder(sortOrder sort.Order) RequestBuilder
 	WithIncludeFields(fields ...string) RequestBuilder
 	WithExcludeFields(fields ...string) RequestBuilder
@@ -107,7 +107,7 @@ func (r *Request) WithFacet(facet *FacetQuery) RequestBuilder {
 	return r
 }
 
-func (r *Request) WithSorting(sortByFields ...sort.Sort) RequestBuilder {
+func (r *Request) WithSorting(sortByFields ...sort.Order) RequestBuilder {
 	r.Sort = sort.NewSortOrder(sortByFields...)
 
 	return r

--- a/sort/sort.go
+++ b/sort/sort.go
@@ -31,19 +31,32 @@ type Sort interface {
 }
 
 // Ascending builds an increasing order for given field name.
-func Ascending(fieldName string) Sort {
-	return &fieldSort{fieldName: fieldName, operator: asc}
+func Ascending(fieldName string) Order {
+	return Order{&fieldSort{fieldName: fieldName, operator: asc}}
 }
 
 // Descending builds a decreasing order for given field name.
-func Descending(fieldName string) Sort {
-	return &fieldSort{fieldName: fieldName, operator: desc}
+func Descending(fieldName string) Order {
+	return Order{&fieldSort{fieldName: fieldName, operator: desc}}
+}
+
+// Ascending builds an increasing order for given field name.
+func (o Order) Ascending(fieldName string) Order {
+	return append(o, &fieldSort{fieldName: fieldName, operator: asc})
+}
+
+// Descending builds a decreasing order for given field name.
+func (o Order) Descending(fieldName string) Order {
+	return append(o, &fieldSort{fieldName: fieldName, operator: desc})
 }
 
 // NewSortOrder creates an array of multiple fields that will be used to sort results.
-func NewSortOrder(sort ...Sort) Order {
-	o := make(Order, len(sort))
-	copy(o, sort)
+func NewSortOrder(sort ...Order) Order {
+	o := make(Order, 0, len(sort))
+	for _, v := range sort {
+		o = append(o, v...)
+	}
+
 	return o
 }
 

--- a/sort/sort_test.go
+++ b/sort/sort_test.go
@@ -24,14 +24,14 @@ import (
 
 func TestAscending(t *testing.T) {
 	s := Ascending("field_1")
-	assert.Equal(t, "field_1", s.FieldName())
-	assert.Equal(t, map[string]string{"field_1": "$asc"}, s.ToSortOrder())
+	assert.Equal(t, "field_1", s[0].FieldName())
+	assert.Equal(t, map[string]string{"field_1": "$asc"}, s[0].ToSortOrder())
 }
 
 func TestDescending(t *testing.T) {
 	s := Descending("field_1")
-	assert.Equal(t, "field_1", s.FieldName())
-	assert.Equal(t, map[string]string{"field_1": "$desc"}, s.ToSortOrder())
+	assert.Equal(t, "field_1", s[0].FieldName())
+	assert.Equal(t, map[string]string{"field_1": "$desc"}, s[0].ToSortOrder())
 }
 
 func TestNewSortOrder(t *testing.T) {
@@ -42,6 +42,13 @@ func TestNewSortOrder(t *testing.T) {
 
 	t.Run("multiple sort orders", func(t *testing.T) {
 		o := NewSortOrder(Descending("field_1"), Ascending("parent.field_2"))
+		assert.Len(t, o, 2)
+		assert.Equal(t, map[string]string{"field_1": "$desc"}, o[0].ToSortOrder())
+		assert.Equal(t, map[string]string{"parent.field_2": "$asc"}, o[1].ToSortOrder())
+	})
+
+	t.Run("multiple sort orders", func(t *testing.T) {
+		o := Descending("field_1").Ascending("parent.field_2")
 		assert.Len(t, o, 2)
 		assert.Equal(t, map[string]string{"field_1": "$desc"}, o[0].ToSortOrder())
 		assert.Equal(t, map[string]string{"parent.field_2": "$asc"}, o[1].ToSortOrder())

--- a/tigris/collection_test.go
+++ b/tigris/collection_test.go
@@ -749,7 +749,7 @@ func TestCollection(t *testing.T) {
 				Limit:  111,
 				Skip:   222,
 				Offset: []byte("333"),
-				Sort:   []byte("[{\"Key1\":\"$asc\"}]"),
+				Sort:   []byte("[{\"Key1\":\"$asc\"},{\"Key2\":\"$desc\"}]"),
 			},
 		).Return(mit, nil)
 		_, err := c.ReadWithOptions(ctx, filter.All,
@@ -758,7 +758,7 @@ func TestCollection(t *testing.T) {
 				Limit:  111,
 				Skip:   222,
 				Offset: []byte("333"),
-				Sort:   sort.NewSortOrder(sort.Ascending("Key1")),
+				Sort:   sort.Ascending("Key1").Descending("Key2"),
 			},
 		)
 		require.NoError(t, err)


### PR DESCRIPTION
Allow passing sort.Ascending directly to the read options. Also allow to chain calls:
sort.Ascending("field1").Descending("field2")