### PR TITLE
Replace standard JSON with jsoniter

### DIFF
--- a/api/server/v1/error.go
+++ b/api/server/v1/error.go
@@ -15,12 +15,12 @@
 package api
 
 import (
-	"encoding/json"
 	"fmt"
 	"time"
 
 	"github.com/golang/protobuf/proto" //nolint:staticcheck
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	jsoniter "github.com/json-iterator/go"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	spb "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc/codes"
@@ -268,7 +268,7 @@ func MarshalStatus(status *spb.Status) ([]byte, error) {
 		}
 	}
 
-	return json.Marshal(&resp)
+	return jsoniter.Marshal(&resp)
 }
 
 // FromErrorDetails construct TigrisError from the ErrorDetails,
@@ -297,7 +297,7 @@ func UnmarshalStatus(b []byte) *TigrisError {
 		Error ErrorDetails `json:"error"`
 	}{}
 
-	if err := json.Unmarshal(b, &resp); err != nil {
+	if err := jsoniter.Unmarshal(b, &resp); err != nil {
 		return &TigrisError{Code: Code_UNKNOWN, Message: err.Error()}
 	}
 

--- a/driver/grpc.go
+++ b/driver/grpc.go
@@ -18,7 +18,6 @@ package driver
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -26,6 +25,7 @@ import (
 	"strings"
 	"unsafe"
 
+	jsoniter "github.com/json-iterator/go"
 	api "github.com/tigrisdata/tigris-client-go/api/server/v1"
 	"github.com/tigrisdata/tigris-client-go/config"
 	"google.golang.org/grpc"
@@ -576,7 +576,7 @@ func (c *grpcCRUD) search(ctx context.Context, collection string, req *SearchReq
 	var err error
 
 	if req.Sort != nil {
-		if b, err = json.Marshal(req.Sort); err != nil {
+		if b, err = jsoniter.Marshal(req.Sort); err != nil {
 			return nil, err
 		}
 	}

--- a/driver/http.go
+++ b/driver/http.go
@@ -28,6 +28,7 @@ import (
 	"time"
 	"unsafe"
 
+	jsoniter "github.com/json-iterator/go"
 	apiHTTP "github.com/tigrisdata/tigris-client-go/api/client/v1/api"
 	api "github.com/tigrisdata/tigris-client-go/api/server/v1"
 	"github.com/tigrisdata/tigris-client-go/config"
@@ -1161,7 +1162,7 @@ func getAccessToken(ctx context.Context, tokenURL string, cfg *config.Driver, cl
 
 	var tr TokenResponse
 
-	err = json.Unmarshal(body, &tr)
+	err = jsoniter.Unmarshal(body, &tr)
 	if err != nil {
 		return nil, api.Errorf(api.Code_INTERNAL, "failed to parse external response: reason = %s", err.Error())
 	}

--- a/driver/search_grpc.go
+++ b/driver/search_grpc.go
@@ -18,9 +18,9 @@ package driver
 
 import (
 	"context"
-	"encoding/json"
 	"unsafe"
 
+	jsoniter "github.com/json-iterator/go"
 	api "github.com/tigrisdata/tigris-client-go/api/server/v1"
 )
 
@@ -181,7 +181,7 @@ func (c *grpcSearch) Search(ctx context.Context, name string, req *SearchRequest
 	var err error
 
 	if req.Sort != nil {
-		if b, err = json.Marshal(req.Sort); err != nil {
+		if b, err = jsoniter.Marshal(req.Sort); err != nil {
 			return nil, err
 		}
 	}

--- a/driver/search_test.go
+++ b/driver/search_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	api "github.com/tigrisdata/tigris-client-go/api/server/v1"
@@ -109,10 +110,10 @@ func testSearchBasic(t *testing.T, c Driver, mc *mock.MockSearchServer) {
 		assert.True(t, sit.Next(&r))
 		require.NoError(t, sit.Err())
 
-		res, err := json.Marshal(r)
+		res, err := jsoniter.Marshal(r)
 		require.NoError(t, err)
 
-		exp, err := json.Marshal(&searchResp)
+		exp, err := jsoniter.Marshal(&searchResp)
 		require.NoError(t, err)
 
 		require.JSONEq(t, string(exp), string(res))

--- a/driver/test.go
+++ b/driver/test.go
@@ -15,12 +15,12 @@
 package driver
 
 import (
-	"encoding/json"
 	"fmt"
 	"testing"
 	"unsafe"
 
 	"github.com/golang/mock/gomock"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
@@ -34,7 +34,15 @@ type JSONMatcher struct {
 }
 
 func (matcher *JSONMatcher) Matches(actual any) bool {
-	return assert.JSONEq(matcher.T, string(matcher.Expected), string(actual.(Schema)))
+	var s string
+	switch t := actual.(type) {
+	case Schema:
+		s = string(t)
+	case Projection:
+		s = string(t)
+	}
+
+	return assert.JSONEq(matcher.T, string(matcher.Expected), s)
 }
 
 func (matcher *JSONMatcher) String() string {
@@ -57,9 +65,9 @@ type JSONArrMatcher struct {
 }
 
 func (matcher *JSONArrMatcher) Matches(actual any) bool {
-	act, err := json.Marshal(actual)
+	act, err := jsoniter.Marshal(actual)
 	require.NoError(matcher.T, err)
-	exp, err := json.Marshal(actual)
+	exp, err := jsoniter.Marshal(actual)
 	require.NoError(matcher.T, err)
 
 	assert.JSONEq(matcher.T, string(exp), string(act))
@@ -82,7 +90,7 @@ func JAM(t *testing.T, expected []string) gomock.Matcher {
 }
 
 func ToDocument(t *testing.T, doc any) Document {
-	b, err := json.Marshal(doc)
+	b, err := jsoniter.Marshal(doc)
 	require.NoError(t, err)
 
 	return b

--- a/fields/read.go
+++ b/fields/read.go
@@ -18,8 +18,7 @@
 package fields
 
 import (
-	"encoding/json"
-
+	jsoniter "github.com/json-iterator/go"
 	"github.com/tigrisdata/tigris-client-go/driver"
 )
 
@@ -68,7 +67,7 @@ func (pr *Read) Build() (*Read, error) {
 
 	var err error
 
-	pr.built, err = json.Marshal(pr.fields)
+	pr.built, err = jsoniter.Marshal(pr.fields)
 
 	return pr, err
 }

--- a/fields/update.go
+++ b/fields/update.go
@@ -20,9 +20,9 @@
 package fields
 
 import (
-	"encoding/json"
 	"fmt"
 
+	jsoniter "github.com/json-iterator/go"
 	"github.com/tigrisdata/tigris-client-go/driver"
 )
 
@@ -60,7 +60,7 @@ func (u *Update) Build() (*Update, error) {
 
 	var err error
 
-	u.built, err = json.Marshal(u)
+	u.built, err = jsoniter.Marshal(u)
 	return u, err
 }
 

--- a/fields/update_test.go
+++ b/fields/update_test.go
@@ -59,7 +59,7 @@ func TestUpdateBasic(t *testing.T) {
 		t.Run(v.name, func(t *testing.T) {
 			b, err := v.fields.Build()
 			assert.Equal(t, v.err, err)
-			assert.Equal(t, v.exp, string(b.Built()))
+			assert.JSONEq(t, v.exp, string(b.Built()))
 		})
 	}
 

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -18,8 +18,7 @@
 package filter
 
 import (
-	"encoding/json"
-
+	jsoniter "github.com/json-iterator/go"
 	"github.com/tigrisdata/tigris-client-go/driver"
 	"github.com/tigrisdata/tigris-client-go/schema"
 )
@@ -116,5 +115,5 @@ func (prev Expr) Build() (driver.Filter, error) {
 		return nil, nil
 	}
 
-	return json.Marshal(prev)
+	return jsoniter.Marshal(prev)
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -26,7 +26,6 @@
 package schema
 
 import (
-	"encoding/json"
 	"fmt"
 	"reflect"
 	"sort"
@@ -259,7 +258,7 @@ func isPrimaryKeyType(tp string) bool {
 
 // Build converts structured schema to driver schema.
 func Build(sch *Schema) (driver.Schema, error) {
-	return json.Marshal(sch)
+	return jsoniter.Marshal(sch)
 }
 
 // Build converts structured schema to driver schema.
@@ -619,14 +618,14 @@ func (f *FieldMultiType) UnmarshalJSON(b []byte) error {
 
 func (f *FieldMultiType) MarshalJSON() ([]byte, error) {
 	if !f.isNullable && len(f.Type) == 1 {
-		return json.Marshal(f.Type[0])
+		return jsoniter.Marshal(f.Type[0])
 	}
 
 	if !f.isNullable {
-		return json.Marshal(f.Type)
+		return jsoniter.Marshal(f.Type)
 	}
 
-	return json.Marshal(append(f.Type, "null"))
+	return jsoniter.Marshal(append(f.Type, "null"))
 }
 
 func (f *FieldMultiType) First() string {

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -15,7 +15,6 @@
 package schema
 
 import (
-	"encoding/json"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -23,6 +22,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -417,11 +417,11 @@ func TestCollectionSchema(t *testing.T) {
 		require.NoError(t, err)
 
 		res := `{"version":5,"title":"all_types","properties":{"PtrStruct":{"type":["object","null"],"properties":{"ss_field_1":{"type":"string"}}},"Tm":{"type":"string","format":"date-time"},"TmPtr":{"type":["string","null"],"format":"date-time"},"UUID":{"type":"string","format":"uuid"},"UUIDPtr":{"type":["string","null"],"format":"uuid"},"arr_1":{"type":"array","items":{"type":"string"},"maxItems":3},"bool_1":{"type":"boolean"},"bool_123":{"type":"boolean"},"bytes_1":{"type":"string","format":"byte"},"bytes_2":{"type":"string","format":"byte"},"data_1":{"type":"object","properties":{"Nested":{"type":"object","properties":{"ss_field_1":{"type":"string"}}},"field_1":{"type":"string"}}},"float_32":{"type":"number"},"float_64":{"type":"number"},"int_1":{"type":"integer"},"int_32":{"type":"integer","format":"int32"},"int_64":{"type":"integer"},"map_1":{"type":"object","additionalProperties":true},"map_2":{"type":"object","additionalProperties":true},"map_any":{"type":"object","additionalProperties":true},"slice_1":{"type":"array","items":{"type":"string"}},"slice_2":{"type":"array","items":{"type":"object","properties":{"Nested":{"type":"object","properties":{"ss_field_1":{"type":"string"}}},"field_1":{"type":"string"}}}},"string_1":{"type":"string"}},"primary_key":["string_1"]}`
-		require.Equal(t, res, string(b))
+		require.JSONEq(t, res, string(b))
 
 		var sch Schema
 
-		err = json.Unmarshal([]byte(res), &sch)
+		err = jsoniter.Unmarshal([]byte(res), &sch)
 		require.NoError(t, err)
 
 		require.Equal(t, s, &sch)
@@ -534,8 +534,8 @@ func TestDefaultsNegative(t *testing.T) {
 		{"int", "integer", "vbn", fmt.Errorf("%w: %s", ErrInvalidDefaultTag, "strconv.ParseInt: parsing \"vbn\": invalid syntax")},
 		{"float", "number", "vbn", fmt.Errorf("%w: %s", ErrInvalidDefaultTag, "strconv.ParseFloat: parsing \"vbn\": invalid syntax")},
 		{"bool", "boolean", "vbn", fmt.Errorf("%w: %s", ErrInvalidDefaultTag, "invalid bool value: vbn")},
-		{"array", "array", "vbn", fmt.Errorf("%w: %s", ErrInvalidDefaultTag, "invalid character 'v' looking for beginning of value")},
-		{"object", "object", "vbn", fmt.Errorf("%w: %s", ErrInvalidDefaultTag, "invalid character 'v' looking for beginning of value")},
+		{"array", "array", "vbn", fmt.Errorf("%w: %s", ErrInvalidDefaultTag, "[]interface {}: decode slice: expect [ or n, but found v, error found in #1 byte of ...|vbn|..., bigger context ...|vbn|...")},
+		{"object", "object", "vbn", fmt.Errorf("%w: %s", ErrInvalidDefaultTag, "ReadMapCB: expect { or n, but found v, error found in #1 byte of ...|vbn|..., bigger context ...|vbn|...")},
 	}
 
 	for _, c := range cases {

--- a/schema/tag.go
+++ b/schema/tag.go
@@ -15,12 +15,12 @@
 package schema
 
 import (
-	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
 
 	"github.com/iancoleman/strcase"
+	jsoniter "github.com/json-iterator/go"
 )
 
 var (
@@ -171,14 +171,14 @@ func parseDefaultTag(f *Field, val string) error {
 	case typeObject:
 		var o map[string]any
 
-		if err := json.Unmarshal([]byte(val), &o); err != nil {
+		if err := jsoniter.Unmarshal([]byte(val), &o); err != nil {
 			return tagError(ErrInvalidDefaultTag, err.Error())
 		}
 
 		f.Default = o
 	case typeArray:
 		var a []any
-		if err := json.Unmarshal([]byte(val), &a); err != nil {
+		if err := jsoniter.Unmarshal([]byte(val), &a); err != nil {
 			return tagError(ErrInvalidDefaultTag, err.Error())
 		}
 

--- a/search/index.go
+++ b/search/index.go
@@ -16,8 +16,8 @@ package search
 
 import (
 	"context"
-	"encoding/json"
 
+	jsoniter "github.com/json-iterator/go"
 	api "github.com/tigrisdata/tigris-client-go/api/server/v1"
 	"github.com/tigrisdata/tigris-client-go/driver"
 	"github.com/tigrisdata/tigris-client-go/filter"
@@ -69,7 +69,7 @@ func (c *Index[T]) createOrReplace(ctx context.Context, tp int, docs ...*T) (*Re
 	bdocs := make([]driver.Document, len(docs))
 
 	for k, v := range docs {
-		if bdocs[k], err = json.Marshal(v); err != nil {
+		if bdocs[k], err = jsoniter.Marshal(v); err != nil {
 			return nil, err
 		}
 	}
@@ -134,7 +134,7 @@ func (c *Index[T]) Get(ctx context.Context, ids []string) ([]T, error) {
 			continue
 		}
 
-		err = json.Unmarshal(v.Data, &doc)
+		err = jsoniter.Unmarshal(v.Data, &doc)
 		if err != nil {
 			return nil, err
 		}

--- a/search/index_test.go
+++ b/search/index_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/require"
 	api "github.com/tigrisdata/tigris-client-go/api/server/v1"
 	"github.com/tigrisdata/tigris-client-go/code"
@@ -305,7 +306,7 @@ func TestSearchIndex(t *testing.T) {
 func createSearchResponse(t *testing.T, doc any) driver.SearchIndexResponse {
 	t.Helper()
 
-	d, err := json.Marshal(doc)
+	d, err := jsoniter.Marshal(doc)
 	require.NoError(t, err)
 	tm := time.Now()
 	return &api.SearchIndexResponse{
@@ -434,7 +435,7 @@ func TestSearchIndex_Search(t *testing.T) {
 		require.Nil(t, searchIter.err)
 		require.False(t, searchIter.Next(&rs))
 		require.NotNil(t, searchIter.err)
-		require.ErrorContains(t, searchIter.err, "cannot unmarshal string")
+		require.ErrorContains(t, searchIter.err, "readObjectStart")
 	})
 }
 

--- a/search/request.go
+++ b/search/request.go
@@ -15,9 +15,9 @@
 package search
 
 import (
-	"encoding/json"
 	"fmt"
 
+	jsoniter "github.com/json-iterator/go"
 	"github.com/tigrisdata/tigris-client-go/driver"
 	"github.com/tigrisdata/tigris-client-go/filter"
 	"github.com/tigrisdata/tigris-client-go/sort"
@@ -204,7 +204,7 @@ func (r *Request) BuildInternal() (*driver.SearchRequest, error) {
 	}
 
 	if req.Vector != nil {
-		b, err := json.Marshal(req.Vector)
+		b, err := jsoniter.Marshal(req.Vector)
 		if err != nil {
 			return nil, err
 		}
@@ -247,7 +247,7 @@ func (f *FacetQuery) Built() (driver.Facet, error) {
 
 	var err error
 
-	f.built, err = json.Marshal(m)
+	f.built, err = jsoniter.Marshal(m)
 
 	return f.built, err
 }

--- a/search/request_test.go
+++ b/search/request_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"testing"
 
+	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tigrisdata/tigris-client-go/driver"
@@ -169,7 +170,7 @@ func ExampleNewRequestBuilder() {
 
 func ExampleRequestBuilder_WithSearchFields() {
 	req := NewRequestBuilder().WithQuery("some text").WithSearchFields("field_1").Build()
-	b, err := json.Marshal(req.SearchFields)
+	b, err := jsoniter.Marshal(req.SearchFields)
 	if err != nil {
 		panic(err)
 	}

--- a/search/response.go
+++ b/search/response.go
@@ -15,9 +15,9 @@
 package search
 
 import (
-	"encoding/json"
 	"time"
 
+	jsoniter "github.com/json-iterator/go"
 	api "github.com/tigrisdata/tigris-client-go/api/server/v1"
 	"github.com/tigrisdata/tigris-client-go/schema"
 )
@@ -112,7 +112,7 @@ type Hit[T schema.Model] struct {
 func (h *Hit[T]) From(apiHit *api.SearchHit) error {
 	if apiHit != nil {
 		var d T
-		if err := json.Unmarshal(apiHit.Data, &d); err != nil {
+		if err := jsoniter.Unmarshal(apiHit.Data, &d); err != nil {
 			return err
 		}
 

--- a/search/response_test.go
+++ b/search/response_test.go
@@ -78,7 +78,7 @@ func TestResult_From(t *testing.T) {
 			Hits: []*api.SearchHit{{Data: []byte(`{"Key1": "aaa", "Field1": "val1"}`)}},
 		})
 		assert.NotNil(t, err)
-		assert.Contains(t, err.Error(), "cannot unmarshal")
+		assert.Contains(t, err.Error(), "search.Coll1.Field1: readUint64: unexpected character")
 	})
 
 	t.Run("from complete response", func(t *testing.T) {
@@ -141,14 +141,14 @@ func TestHit_From(t *testing.T) {
 		h := &Hit[Coll1]{}
 		err := h.From(&api.SearchHit{})
 		assert.NotNil(t, err)
-		assert.Equal(t, "unexpected end of JSON input", err.Error())
+		assert.Contains(t, err.Error(), "readObjectStart")
 	})
 
 	t.Run("from missing collection document", func(t *testing.T) {
 		h := &Hit[Coll1]{}
 		err := h.From(&api.SearchHit{Metadata: &api.SearchHitMeta{CreatedAt: timestamppb.Now()}})
 		assert.NotNil(t, err)
-		assert.Equal(t, "unexpected end of JSON input", err.Error())
+		assert.Contains(t, err.Error(), "readObjectStart")
 	})
 
 	t.Run("from document with missing values", func(t *testing.T) {
@@ -172,7 +172,7 @@ func TestHit_From(t *testing.T) {
 			Metadata: &api.SearchHitMeta{CreatedAt: timestamppb.Now()},
 		})
 		assert.NotNil(t, err)
-		assert.Contains(t, err.Error(), "cannot unmarshal")
+		assert.Contains(t, err.Error(), "search.Coll1.Field1: readUint64: unexpected character")
 	})
 
 	t.Run("from valid response", func(t *testing.T) {

--- a/sort/sort.go
+++ b/sort/sort.go
@@ -17,6 +17,7 @@ package sort
 import (
 	"encoding/json"
 
+	jsoniter "github.com/json-iterator/go"
 	"github.com/tigrisdata/tigris-client-go/driver"
 )
 
@@ -73,7 +74,7 @@ func (o Expr) Built() (driver.SortOrder, error) {
 
 	sortOrders := make([]json.RawMessage, len(o))
 	for i, s := range o {
-		b, err := json.Marshal(s.ToSortOrder())
+		b, err := jsoniter.Marshal(s.ToSortOrder())
 		if err != nil {
 			return nil, err
 		}

--- a/tigris/collection.go
+++ b/tigris/collection.go
@@ -16,9 +16,9 @@ package tigris
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
+	jsoniter "github.com/json-iterator/go"
 	api "github.com/tigrisdata/tigris-client-go/api/server/v1"
 	"github.com/tigrisdata/tigris-client-go/code"
 	"github.com/tigrisdata/tigris-client-go/driver"
@@ -72,7 +72,7 @@ func (c *Collection[T]) Insert(ctx context.Context, docs ...*T) (*InsertResponse
 	bdocs := make([]driver.Document, len(docs))
 
 	for k, v := range docs {
-		if bdocs[k], err = json.Marshal(v); err != nil {
+		if bdocs[k], err = jsoniter.Marshal(v); err != nil {
 			return nil, err
 		}
 	}
@@ -107,7 +107,7 @@ func (c *Collection[T]) InsertOrReplace(ctx context.Context, docs ...*T) (*Inser
 	bdocs := make([]driver.Document, len(docs))
 
 	for k, v := range docs {
-		if bdocs[k], err = json.Marshal(v); err != nil {
+		if bdocs[k], err = jsoniter.Marshal(v); err != nil {
 			return nil, err
 		}
 	}
@@ -234,7 +234,7 @@ func (c *Collection[T]) ReadWithOptions(ctx context.Context, filter filter.Filte
 		if err != nil {
 			return nil, err
 		}
-		sortOrderbytes, err = json.Marshal(sortOrder)
+		sortOrderbytes, err = jsoniter.Marshal(sortOrder)
 		if err != nil {
 			return nil, err
 		}
@@ -371,7 +371,7 @@ func (c *Collection[T]) Explain(ctx context.Context, filter filter.Filter, field
 		if err != nil {
 			return nil, err
 		}
-		sortOrderbytes, err = json.Marshal(sortOrder)
+		sortOrderbytes, err = jsoniter.Marshal(sortOrder)
 		if err != nil {
 			return nil, err
 		}

--- a/tigris/iterator.go
+++ b/tigris/iterator.go
@@ -15,8 +15,7 @@
 package tigris
 
 import (
-	"encoding/json"
-
+	jsoniter "github.com/json-iterator/go"
 	"github.com/tigrisdata/tigris-client-go/driver"
 	"github.com/tigrisdata/tigris-client-go/search"
 )
@@ -50,7 +49,7 @@ func (it *Iterator[T]) Next(doc *T) bool {
 	if it.unmarshaler != nil {
 		err = it.unmarshaler(b, &v)
 	} else {
-		err = json.Unmarshal(b, &v)
+		err = jsoniter.Unmarshal(b, &v)
 	}
 
 	if err != nil {

--- a/tigris/model.go
+++ b/tigris/model.go
@@ -15,10 +15,10 @@
 package tigris
 
 import (
-	"encoding/json"
 	"time"
 
 	"github.com/google/uuid"
+	jsoniter "github.com/json-iterator/go"
 	api "github.com/tigrisdata/tigris-client-go/api/server/v1"
 )
 
@@ -96,5 +96,5 @@ func populateModelMetadata(umodel any, md *api.ResponseMetadata, keys []byte) er
 		return nil
 	}
 
-	return json.Unmarshal(keys, umodel)
+	return jsoniter.Unmarshal(keys, umodel)
 }

--- a/tigris/model_test.go
+++ b/tigris/model_test.go
@@ -16,12 +16,12 @@ package tigris
 
 import (
 	"context"
-	"encoding/json"
 	"testing"
 	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/require"
 	api "github.com/tigrisdata/tigris-client-go/api/server/v1"
 	"github.com/tigrisdata/tigris-client-go/driver"
@@ -155,7 +155,7 @@ func TestModelMetadata(t *testing.T) {
 
 		exp := &Coll2{Int: 123, Int64: 456, Time: tm, UUID: uuid.MustParse(id1), String: "str1", Float64: 123.123}
 
-		b, err := json.Marshal(exp)
+		b, err := jsoniter.Marshal(exp)
 		require.NoError(t, err)
 
 		mdb.EXPECT().Replace(ctx, "coll_2",

--- a/tigris/projection.go
+++ b/tigris/projection.go
@@ -16,12 +16,12 @@ package tigris
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
 
 	"github.com/buger/jsonparser"
+	jsoniter "github.com/json-iterator/go"
 	api "github.com/tigrisdata/tigris-client-go/api/server/v1"
 	"github.com/tigrisdata/tigris-client-go/driver"
 	"github.com/tigrisdata/tigris-client-go/fields"
@@ -324,8 +324,8 @@ func (p *Projection[T, P]) projectionUnmarshal(b []byte, v *P) error {
 			return err
 		}
 
-		return json.Unmarshal(sub, v)
+		return jsoniter.Unmarshal(sub, v)
 	}
 
-	return json.Unmarshal(b, v)
+	return jsoniter.Unmarshal(b, v)
 }

--- a/tigris/tx_test.go
+++ b/tigris/tx_test.go
@@ -83,7 +83,7 @@ func TestCollectionTx(t *testing.T) {
 
 		mtx.EXPECT().Read(ctx, "coll_1",
 			driver.Filter(`{"$or":[{"Key1":{"$eq":"aaa"}},{"Key1":{"$eq":"ccc"}}]}`),
-			driver.Projection(`{"Field1":true,"Key1":false}`),
+			jm(t, `{"Field1":true,"Key1":false}`),
 			&driver.ReadOptions{
 				Limit:  111,
 				Skip:   222,

--- a/timeseries/timeseries_test.go
+++ b/timeseries/timeseries_test.go
@@ -16,12 +16,12 @@ package timeseries
 
 import (
 	"context"
-	"encoding/json"
 	"testing"
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/golang/mock/gomock"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/require"
 	"github.com/tigrisdata/tigris-client-go/driver"
 	"github.com/tigrisdata/tigris-client-go/filter"
@@ -81,7 +81,7 @@ func TestTimeseries(t *testing.T) {
 	// test find after
 	mit := mock.NewMockIterator(ctrl)
 
-	b, err := json.Marshal(ts)
+	b, err := jsoniter.Marshal(ts)
 	require.NoError(t, err)
 
 	mdb.EXPECT().Read(ctx, "coll_1",
@@ -117,7 +117,7 @@ func TestTimeseries(t *testing.T) {
 	}
 
 	tsAfter := time.Now().Add(1 * time.Second)
-	b1, err := json.Marshal(tsAfter)
+	b1, err := jsoniter.Marshal(tsAfter)
 	require.NoError(t, err)
 
 	// test find before


### PR DESCRIPTION
## Description
This PR introduces `jsoniter` to the go client and uses `jsoniter` for operations like Marshal, Unmarshal but for operations like RawMessage and Number we still use `encoding/json`

## Issue
https://github.com/tigrisdata/tigris-client-go/issues/265